### PR TITLE
Changed needs_new_cache_change to _needs_new_cache_change in dp_event…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ src/.vscode/launch.json
 *.code-workspace
 *.bin
 /log/
+.vscode/launch.json

--- a/src/dds/dp_event_loop.rs
+++ b/src/dds/dp_event_loop.rs
@@ -231,8 +231,8 @@ impl DPEventLoop {
 
               WriterLost{writer_guid} => ev_wrapper.remote_writer_lost(writer_guid) ,
 
-              ReaderUpdated{ discovered_reader_data, rtps_reader_proxy, needs_new_cache_change } => 
-                ev_wrapper.remote_reader_discovered(discovered_reader_data, rtps_reader_proxy, needs_new_cache_change),
+              ReaderUpdated{ discovered_reader_data, rtps_reader_proxy, _needs_new_cache_change } => 
+                ev_wrapper.remote_reader_discovered(discovered_reader_data, rtps_reader_proxy, _needs_new_cache_change),
 
               ReaderLost{ reader_guid } => ev_wrapper.remote_reader_lost(reader_guid) ,
 
@@ -606,7 +606,7 @@ impl DPEventLoop {
   }
 
   fn remote_reader_discovered(&mut self, drd: DiscoveredReaderData, 
-      rtps_reader_proxy: RtpsReaderProxy , needs_new_cache_change: bool) {
+      rtps_reader_proxy: RtpsReaderProxy , _needs_new_cache_change: bool) {
     for (_writer_guid, writer) in self.writers.iter_mut() {
       if drd.subscription_topic_data.topic_name() == writer.topic_name() {
         writer.update_reader_proxy(rtps_reader_proxy.clone(), 

--- a/src/discovery/discovery.rs
+++ b/src/discovery/discovery.rs
@@ -588,7 +588,7 @@ impl Discovery {
     self.send_discovery_notification(DiscoveryNotificationType::ReaderUpdated
       { rtps_reader_proxy:  RtpsReaderProxy::from_discovered_reader_data(&drd,vec![], vec![]),
         discovered_reader_data: drd,
-        needs_new_cache_change: true,
+        _needs_new_cache_change: true,
       });
   }
 
@@ -641,7 +641,7 @@ impl Discovery {
                   DiscoveryNotificationType::ReaderUpdated {
                     discovered_reader_data: drd, 
                     rtps_reader_proxy,
-                    needs_new_cache_change: true,
+                    _needs_new_cache_change: true,
                   });  
               }
               db.update_topic_data_drd(&val);

--- a/src/network/constant.rs
+++ b/src/network/constant.rs
@@ -99,7 +99,7 @@ pub(crate) enum DiscoveryNotificationType {
   ReaderUpdated { 
     rtps_reader_proxy: RtpsReaderProxy,
     discovered_reader_data: DiscoveredReaderData , 
-    needs_new_cache_change: bool 
+    _needs_new_cache_change: bool 
   },
   ReaderLost { reader_guid: GUID }, 
   WriterUpdated { discovered_writer_data: DiscoveredWriterData  },


### PR DESCRIPTION
…_loop.rs, discovery.rs, and constant.rs to get rid of an unused variable warning.

The warning said to suppress the fact that `#[warn(unused_variables)]` is on by default by renaming it to `_needs_new_cache_change` so I did. That's what this PR is. Also my Rust VSCode extension wants me to open the root directory containing Cargo.toml so I excluded my .vscode directory in .gitignore.