### PR TITLE
impl find_topic for DomainParticipant

### DIFF
--- a/src/dds/participant.rs
+++ b/src/dds/participant.rs
@@ -4,12 +4,13 @@ use mio_extras::channel as mio_channel;
 use log::{error, debug, info, warn, trace};
 
 use std::{
+  collections::HashMap,
+  intrinsics::discriminant_value,
+  net::Ipv4Addr,
+  sync::{Arc, RwLock, Mutex, Weak},
   thread,
   thread::JoinHandle,
-  collections::HashMap,
   time::Duration,
-  sync::{Arc, RwLock, Mutex, Weak,},
-  net::Ipv4Addr,
 };
 
 use crate::log_and_err_internal;
@@ -20,8 +21,8 @@ use crate::{
 };
 
 use crate::dds::{
-  dp_event_loop::DPEventLoop, reader::*, writer::Writer, pubsub::*, topic::*, typedesc::*,
-  qos::*, values::result::*,
+  dp_event_loop::DPEventLoop, reader::*, writer::Writer, pubsub::*, topic::*, typedesc::*, qos::*,
+  values::result::*,
 };
 
 use crate::{
@@ -35,7 +36,8 @@ use crate::{
 
 use super::dp_event_loop::DomainInfo;
 
-/// DDS DomainParticipant generally only one per domain per machine should be active
+/// DDS DomainParticipant generally only one per domain per machine should be
+/// active
 #[derive(Clone)]
 // This is a smart pointer for DomainParticipant_Inner for easier manipulation.
 pub struct DomainParticipant {
@@ -66,7 +68,9 @@ impl DomainParticipant {
       None => return log_and_err_internal!("Unable to get Discovery Command Receiver."),
     };
 
-    let dp = DomainParticipant { dpi: Arc::new(Mutex::new(dpd) ) };
+    let dp = DomainParticipant {
+      dpi: Arc::new(Mutex::new(dpd)),
+    };
 
     let (discovery_started_sender, discovery_started_receiver) =
       std::sync::mpsc::channel::<Result<()>>();
@@ -79,23 +83,23 @@ impl DomainParticipant {
       discovery_command_receiver,
     );
 
-    let discovery_handle = 
-          thread::Builder::new()
-            .name("RustDDS discovery thread".to_string())
-            .spawn(move || Discovery::discovery_event_loop(discovery))?;
+    let discovery_handle = thread::Builder::new()
+      .name("RustDDS discovery thread".to_string())
+      .spawn(move || Discovery::discovery_event_loop(discovery))?;
     djh_sender.send(discovery_handle).unwrap_or(());
 
-    debug!("Waiting for discovery to start"); // blocking until discovery answers   
+    debug!("Waiting for discovery to start"); // blocking until discovery answers
     match discovery_started_receiver.recv_timeout(Duration::from_secs(10)) {
-      Ok(Ok( () )) => { // normal case
-        info!("Discovery started. Participant constructed."); 
-        Ok(dp) 
-      },
+      Ok(Ok(())) => {
+        // normal case
+        info!("Discovery started. Participant constructed.");
+        Ok(dp)
+      }
       Ok(Err(e)) => {
         std::mem::drop(dp);
         log_and_err_internal!("Failed to start discovery thread: {:?}", e)
       }
-      Err(e) => log_and_err_internal!("Discovery thread channel error: {:?}",e),
+      Err(e) => log_and_err_internal!("Discovery thread channel error: {:?}", e),
     }
   }
 
@@ -103,7 +107,8 @@ impl DomainParticipant {
   ///
   /// # Arguments
   ///
-  /// * `qos` - Takes [qos policies](qos/struct.QosPolicies.html) for publisher and given to DataWriter as default.
+  /// * `qos` - Takes [qos policies](qos/struct.QosPolicies.html) for publisher
+  ///   and given to DataWriter as default.
   ///
   /// # Examples
   ///
@@ -123,7 +128,8 @@ impl DomainParticipant {
   ///
   /// # Arguments
   ///
-  /// * `qos` - Takes [qos policies](qos/struct.QosPolicies.html) for subscriber and given to DataReader as default.
+  /// * `qos` - Takes [qos policies](qos/struct.QosPolicies.html) for subscriber
+  ///   and given to DataReader as default.
   ///
   /// # Examples
   ///
@@ -135,7 +141,7 @@ impl DomainParticipant {
   /// let subscriber = domain_participant.create_subscriber(&qos);
   /// ```
   pub fn create_subscriber(&self, qos: &QosPolicies) -> Result<Subscriber> {
-    //println!("DP(outer): create_subscriber");
+    // println!("DP(outer): create_subscriber");
     let w = self.weak_clone(); // do this first, avoid deadlock
     self.dpi.lock().unwrap().create_subscriber(&w, qos)
   }
@@ -146,7 +152,8 @@ impl DomainParticipant {
   ///
   /// * `name` - Name of the topic.
   /// * `type_desc` - Name of the type this topic is supposed to deliver.
-  /// * `qos` - Takes [qos policies](qos/struct.QosPolicies.html) that are distributed to DataReaders and DataWriters.
+  /// * `qos` - Takes [qos policies](qos/struct.QosPolicies.html) that are
+  ///   distributed to DataReaders and DataWriters.
   ///
   /// # Examples
   ///
@@ -166,11 +173,12 @@ impl DomainParticipant {
     qos: &QosPolicies,
     topic_kind: TopicKind,
   ) -> Result<Topic> {
-    //println!("Create topic outer");
+    // println!("Create topic outer");
     let w = self.weak_clone();
     self
       .dpi
-      .lock().unwrap()
+      .lock()
+      .unwrap()
       .create_topic(&w, name, type_desc, qos, topic_kind)
   }
 
@@ -212,8 +220,8 @@ impl DomainParticipant {
     self.dpi.lock().unwrap().get_discovered_topics()
   }
 
-  /// Manually asserts liveliness, affecting all writers with 
-  /// LIVELINESS QoS of MANUAL_BY_PARTICIPANT created by 
+  /// Manually asserts liveliness, affecting all writers with
+  /// LIVELINESS QoS of MANUAL_BY_PARTICIPANT created by
   /// this particular participant.
   ///
   /// # Example
@@ -223,10 +231,9 @@ impl DomainParticipant {
   /// let domain_participant = DomainParticipant::new(0).expect("Failed to create participant");
   /// domain_participant.assert_liveliness();
   /// ```
-  pub fn assert_liveliness(self) -> Result<()>{
+  pub fn assert_liveliness(self) -> Result<()> {
     self.dpi.lock().unwrap().assert_liveliness()
   }
-
 
   pub(crate) fn weak_clone(&self) -> DomainParticipantWeak {
     DomainParticipantWeak::new(self.clone(), self.get_guid())
@@ -237,7 +244,15 @@ impl DomainParticipant {
   }
 
   pub(crate) fn discovery_db(&self) -> Arc<RwLock<DiscoveryDB>> {
-    self.dpi.lock().unwrap().dpi.lock().unwrap().discovery_db.clone()
+    self
+      .dpi
+      .lock()
+      .unwrap()
+      .dpi
+      .lock()
+      .unwrap()
+      .discovery_db
+      .clone()
   }
 }
 
@@ -248,7 +263,6 @@ impl PartialEq for DomainParticipant {
       && self.participant_id() == other.participant_id()
   }
 }
-
 
 #[derive(Clone)]
 pub struct DomainParticipantWeak {
@@ -287,7 +301,10 @@ impl DomainParticipantWeak {
     topic_kind: TopicKind,
   ) -> Result<Topic> {
     match self.dpi.upgrade() {
-      Some(dpi) => dpi.lock().unwrap().create_topic(&self, name, type_desc, qos, topic_kind),
+      Some(dpi) => dpi
+        .lock()
+        .unwrap()
+        .create_topic(&self, name, type_desc, qos, topic_kind),
       None => Err(Error::LockPoisoned),
     }
   }
@@ -319,9 +336,7 @@ impl DomainParticipantWeak {
       None => None,
     }
   }
- 
 } // end impl
-
 
 impl RTPSEntity for DomainParticipantWeak {
   fn get_guid(&self) -> GUID {
@@ -329,7 +344,8 @@ impl RTPSEntity for DomainParticipantWeak {
   }
 }
 
-// This struct exists only to control and stop Discovery when DomainParticipant should be dropped
+// This struct exists only to control and stop Discovery when DomainParticipant
+// should be dropped
 pub(crate) struct DomainParticipant_Disc {
   dpi: Arc<Mutex<DomainParticipant_Inner>>,
   // Discovery control
@@ -366,9 +382,11 @@ impl DomainParticipant_Disc {
     dp: &DomainParticipantWeak,
     qos: &QosPolicies,
   ) -> Result<Publisher> {
-    self.dpi.lock().unwrap().create_publisher(&dp, qos, 
-      self.discovery_command_channel.clone() 
-    )
+    self
+      .dpi
+      .lock()
+      .unwrap()
+      .create_publisher(&dp, qos, self.discovery_command_channel.clone())
   }
 
   pub fn create_subscriber<'a>(
@@ -376,9 +394,11 @@ impl DomainParticipant_Disc {
     dp: &DomainParticipantWeak,
     qos: &QosPolicies,
   ) -> Result<Subscriber> {
-    self.dpi.lock().unwrap().create_subscriber(&dp, qos, 
-      self.discovery_command_channel.clone() 
-    )
+    self
+      .dpi
+      .lock()
+      .unwrap()
+      .create_subscriber(&dp, qos, self.discovery_command_channel.clone())
   }
 
   pub fn create_topic(
@@ -389,8 +409,12 @@ impl DomainParticipant_Disc {
     qos: &QosPolicies,
     topic_kind: TopicKind,
   ) -> Result<Topic> {
-    //println!("Create topic disc");
-    self.dpi.lock().unwrap().create_topic(&dp, name, type_desc, qos, topic_kind)
+    // println!("Create topic disc");
+    self
+      .dpi
+      .lock()
+      .unwrap()
+      .create_topic(&dp, name, type_desc, qos, topic_kind)
   }
 
   pub fn domain_id(&self) -> u16 {
@@ -417,18 +441,20 @@ impl DomainParticipant_Disc {
     // No point in checking for the LIVELINESS QoS of MANUAL_BY_PARTICIPANT,
     // the discovery command mutates a field which is only read
     // by writers with that particular QoS.
-    self.discovery_command_channel.send(DiscoveryCommand::MANUAL_ASSERT_LIVELINESS)
-        .or_else( |e| {
-          log_and_err_internal!(
-            "assert_liveness - Failed to send DiscoveryCommand. {:?}", e)
-        })
+    self
+      .discovery_command_channel
+      .send(DiscoveryCommand::MANUAL_ASSERT_LIVELINESS)
+      .or_else(|e| {
+        log_and_err_internal!("assert_liveness - Failed to send DiscoveryCommand. {:?}", e)
+      })
   }
 }
 
 impl Drop for DomainParticipant_Disc {
   fn drop(&mut self) {
     debug!("Sending Discovery Stop signal.");
-    match self.discovery_command_channel
+    match self
+      .discovery_command_channel
       .send(DiscoveryCommand::STOP_DISCOVERY)
     {
       Ok(_) => (),
@@ -465,7 +491,7 @@ pub(crate) struct DomainParticipant_Inner {
   // dp_event_loop control
   stop_poll_sender: mio_channel::Sender<()>,
   ev_loop_handle: Option<JoinHandle<()>>, // this is Option, because it needs to be extracted
-  // out of the struct (take) in order to .join() on the handle. 
+  // out of the struct (take) in order to .join() on the handle.
 
   // Writers
   add_writer_sender: mio_channel::SyncSender<Writer>,
@@ -477,7 +503,8 @@ pub(crate) struct DomainParticipant_Inner {
 
 impl Drop for DomainParticipant_Inner {
   fn drop(&mut self) {
-    // if send has an error simply leave as we have lost control of the ev_loop_thread anyways
+    // if send has an error simply leave as we have lost control of the
+    // ev_loop_thread anyways
     match self.stop_poll_sender.send(()) {
       Ok(_) => (),
       _ => return (),
@@ -487,8 +514,9 @@ impl Drop for DomainParticipant_Inner {
 
     match self.ev_loop_handle.take() {
       Some(join_handle) => {
-        join_handle.join()
-          .unwrap_or_else(|e| warn!("Failed to join dp_event_loop: {:?}",e));
+        join_handle
+          .join()
+          .unwrap_or_else(|e| warn!("Failed to join dp_event_loop: {:?}", e));
       }
       None => {
         error!("Someone managed to steal dp_event_loop join handle from DomainParticipant_Inner.");
@@ -628,15 +656,15 @@ impl DomainParticipant_Inner {
     );
     // Launch the background thread for DomainParticipant
     let ev_loop_handle = thread::Builder::new()
-          .name("RustDDS Participant event loop".to_string())
-          .spawn(move || ev_wrapper.event_loop())?;
+      .name("RustDDS Participant event loop".to_string())
+      .spawn(move || ev_wrapper.event_loop())?;
 
     Ok(DomainParticipant_Inner {
       domain_id,
       participant_id,
-      my_guid: new_guid ,
+      my_guid: new_guid,
       reader_binds: HashMap::new(),
-      //ddscache: a_r_cache,
+      // ddscache: a_r_cache,
       // Adding readers
       sender_add_reader,
       sender_remove_reader,
@@ -667,9 +695,9 @@ impl DomainParticipant_Inner {
 
   // Publisher and subscriber creation
   //
-  // There are no delete function for publisher or subscriber. Deletion is performed by
-  // deleting the Publisher or Subscriber object, who upon deletion will notify
-  // the DomainParticipant.
+  // There are no delete function for publisher or subscriber. Deletion is
+  // performed by deleting the Publisher or Subscriber object, who upon deletion
+  // will notify the DomainParticipant.
   pub fn create_publisher(
     &self,
     domain_participant: &DomainParticipantWeak,
@@ -702,10 +730,12 @@ impl DomainParticipant_Inner {
     ))
   }
 
-  // Topic creation. Data types should be handled as something (potentially) more structured than a String.
-  // NOTE: Here we are using &str for topic name. &str is Unicode string, whereas DDS specifes topic name
-  // to be a sequence of octets, which would be &[u8] in Rust. This may cause problems if there are topic names
-  // with non-ASCII characters. On the other hand, string handling with &str is easier in Rust.
+  // Topic creation. Data types should be handled as something (potentially) more
+  // structured than a String. NOTE: Here we are using &str for topic name. &str
+  // is Unicode string, whereas DDS specifes topic name to be a sequence of
+  // octets, which would be &[u8] in Rust. This may cause problems if there are
+  // topic names with non-ASCII characters. On the other hand, string handling
+  // with &str is easier in Rust.
   pub fn create_topic(
     &self,
     domain_participant_weak: &DomainParticipantWeak,
@@ -728,16 +758,70 @@ impl DomainParticipant_Inner {
 
   // Do not implement contentfilteredtopics or multitopics (yet)
 
-  pub fn find_topic(self, _name: &str, _timeout: Duration) -> Result<Topic> {
-    unimplemented!()
+  pub fn find_topic(
+    &self,
+    domain_participant_weak: &DomainParticipantWeak,
+    name: &str,
+    timeout: Duration,
+  ) -> Result<Option<Topic>> {
+    let db = if let Ok(db) = self.discovery_db.read() {
+      db
+    } else {
+      return Err(Error::LockPoisoned);
+    };
+
+    if let Some(discovered_topic) = db.get_all_topics().find(|&d| d.get_topic_name() == name) {
+      // build a Topic from DiscoveredTopicData
+      let qos = discovered_topic.topic_data.get_qos();
+      let topic_kind = if discovered_topic.topic_data.key.is_some() {
+        TopicKind::WithKey
+      } else {
+        TopicKind::NoKey
+      };
+      let topic = self
+        .create_topic(
+          domain_participant_weak,
+          discovered_topic.get_topic_name(),
+          &discovered_topic.topic_data.type_name,
+          &qos,
+          topic_kind,
+        )
+        .expect("failed to create topic");
+      return Ok(Some(topic));
+    }
+
+    std::thread::sleep(timeout);
+
+    if let Some(discovered_topic) = db.get_all_topics().find(|&d| d.get_topic_name() == name) {
+      // build a Topic from DiscoveredTopicData
+      let qos = discovered_topic.topic_data.get_qos();
+      let topic_kind = if discovered_topic.topic_data.key.is_some() {
+        TopicKind::WithKey
+      } else {
+        TopicKind::NoKey
+      };
+      let topic = self
+        .create_topic(
+          domain_participant_weak,
+          discovered_topic.get_topic_name(),
+          &discovered_topic.topic_data.type_name,
+          &qos,
+          topic_kind,
+        )
+        .expect("failed to create topic");
+      return Ok(Some(topic));
+    } else {
+      Ok(None)
+    }
   }
 
   // get_builtin_subscriber (why would we need this?)
 
   // ignore_* operations. TODO: Do we needa any of those?
 
-  // delete_contained_entities is not needed. Data structures shoud be designed so that lifetime of all
-  // created objects is within the lifetime of DomainParticipant. Then such deletion is implicit.
+  // delete_contained_entities is not needed. Data structures shoud be designed so
+  // that lifetime of all created objects is within the lifetime of
+  // DomainParticipant. Then such deletion is implicit.
 
   // The following methods are not for application use.
 
@@ -858,9 +942,7 @@ mod tests {
       .expect("Failed to create topic");
 
     let mut _data_writer = publisher
-      .create_datawriter::<RandomData, CDRSerializerAdapter<RandomData, LittleEndian>>(
-        topic, None,
-      )
+      .create_datawriter::<RandomData, CDRSerializerAdapter<RandomData, LittleEndian>>(topic, None)
       .expect("Failed to create datawriter");
   }
 
@@ -881,20 +963,20 @@ mod tests {
       .expect("Failed to create topic");
 
     let mut _data_writer = publisher
-      .create_datawriter::<RandomData, CDRSerializerAdapter<RandomData, LittleEndian>>(
-        topic, None,
-      )
+      .create_datawriter::<RandomData, CDRSerializerAdapter<RandomData, LittleEndian>>(topic, None)
       .expect("Failed to create datawriter");
 
     let portNumber: u16 = get_user_traffic_unicast_port(5, 0);
     let _sender = UDPSender::new(1234);
     let mut m: Message = Message::default();
 
-
     let a: AckNack = AckNack {
       reader_id: EntityId::ENTITYID_SPDP_BUILTIN_PARTICIPANT_READER,
       writer_id: EntityId::ENTITYID_SPDP_BUILTIN_PARTICIPANT_WRITER,
-      reader_sn_state: SequenceNumberSet::from_base_and_set(SequenceNumber::default(), &BTreeSet::new()),
+      reader_sn_state: SequenceNumberSet::from_base_and_set(
+        SequenceNumber::default(),
+        &BTreeSet::new(),
+      ),
       count: 1,
     };
     let flags = BitFlags::<ACKNACK_Flags>::from_endianness(Endianness::BigEndian);
@@ -925,7 +1007,8 @@ mod tests {
         0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
         0x00,
       ],
-      //address: [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x7F, 0x00, 0x00, 0x01],
+      /* address: [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x7F,
+       * 0x00, 0x00, 0x01], */
     };
     let locas = vec![loca];
     _sender.send_to_locator_list(&_data, &locas);

--- a/src/discovery/data_types/topic_data.rs
+++ b/src/discovery/data_types/topic_data.rs
@@ -1,4 +1,3 @@
-
 use std::time::Instant;
 
 use serde::{Serialize, Deserialize, de};
@@ -12,7 +11,7 @@ use crate::{
       TimeBasedFilter, Presentation, Lifespan, History, ResourceLimits,
     },
     traits::key::Keyed,
-    traits::serde_adapters::with_key::SerializerAdapter,  // these are WITH_KEY data
+    traits::serde_adapters::with_key::SerializerAdapter, // these are WITH_KEY data
     rtps_reader_proxy::RtpsReaderProxy,
     reader::Reader,
     participant::DomainParticipant,
@@ -30,12 +29,14 @@ use crate::{
     builtin_data_serializer::BuiltinDataSerializer,
     builtin_data_deserializer::BuiltinDataDeserializer,
   },
-  structure::{entity::RTPSEntity, guid::GUID, guid::GuidPrefix, guid::EntityKind,
-  locator::LocatorList},
+  structure::{
+    entity::RTPSEntity, guid::GUID, guid::GuidPrefix, guid::EntityKind, locator::LocatorList,
+  },
 };
 
-// Topic data contains all topic related 
-// (including reader and writer data structures for serialization and deserialization)
+// Topic data contains all topic related
+// (including reader and writer data structures for serialization and
+// deserialization)
 
 /// Type specified in RTPS v2.3 spec Figure 8.30
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -75,7 +76,9 @@ impl<'de> Deserialize<'de> for ReaderProxy {
   {
     let custom_ds = BuiltinDataDeserializer::new();
     let res = deserializer.deserialize_any(custom_ds)?;
-    res.generate_reader_proxy().ok_or(de::Error::custom("proxy desrialization"))
+    res
+      .generate_reader_proxy()
+      .ok_or(de::Error::custom("proxy desrialization"))
   }
 }
 
@@ -99,8 +102,8 @@ impl Serialize for ReaderProxy {
 pub struct SubscriptionBuiltinTopicData {
   key: GUID,
   participant_key: Option<GUID>,
-  topic_name: String,   
-  type_name: String,    
+  topic_name: String,
+  type_name: String,
   durability: Option<Durability>,
   deadline: Option<Deadline>,
   latency_budget: Option<LatencyBudget>,
@@ -162,7 +165,7 @@ impl SubscriptionBuiltinTopicData {
     self.participant_key = Some(participant_key);
   }
 
-  pub fn topic_name(&self) -> &String{
+  pub fn topic_name(&self) -> &String {
     &self.topic_name
   }
 
@@ -242,9 +245,9 @@ impl SubscriptionBuiltinTopicData {
       time_based_filter: self.time_based_filter,
       reliability: self.reliability,
       destination_order: self.destination_order,
-      history: None, // TODO: Check that this really does not exist in source
+      history: None,         // TODO: Check that this really does not exist in source
       resource_limits: None, // TODO: Check that this really does not exist in source
-      lifespan: self.lifespan, 
+      lifespan: self.lifespan,
     }
   }
 }
@@ -345,16 +348,15 @@ impl DiscoveredReaderData {
 }
 
 // separate type is needed to serialize correctly
-#[derive(Eq,PartialEq,Ord,PartialOrd,Debug, Clone, Copy, Hash)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Copy, Hash)]
 pub struct DiscoveredReaderData_Key(pub GUID);
 
 impl Key for DiscoveredReaderData_Key {}
 
-
 impl Keyed for DiscoveredReaderData {
   type K = DiscoveredReaderData_Key;
   fn get_key(&self) -> Self::K {
-    DiscoveredReaderData_Key( self.subscription_topic_data.key )
+    DiscoveredReaderData_Key(self.subscription_topic_data.key)
   }
 }
 
@@ -406,7 +408,6 @@ impl Serialize for DiscoveredReaderData_Key {
   }
 }
 
-
 // =======================================================================
 // =======================================================================
 // =======================================================================
@@ -442,7 +443,9 @@ impl<'de> Deserialize<'de> for WriterProxy {
   {
     let custom_ds = BuiltinDataDeserializer::new();
     let res = deserializer.deserialize_any(custom_ds)?;
-    res.generate_writer_proxy().ok_or(de::Error::custom("WriterProxy deserialization"))
+    res
+      .generate_writer_proxy()
+      .ok_or(de::Error::custom("WriterProxy deserialization"))
   }
 }
 
@@ -528,7 +531,7 @@ impl PublicationBuiltinTopicData {
       time_based_filter: self.time_based_filter,
       reliability: self.reliability,
       destination_order: self.destination_order,
-      history: None, // TODO: ???
+      history: None,         // TODO: ???
       resource_limits: None, // TODO: ???
       lifespan: self.lifespan,
     }
@@ -542,7 +545,9 @@ impl<'de> Deserialize<'de> for PublicationBuiltinTopicData {
   {
     let custom_ds = BuiltinDataDeserializer::new();
     let res = deserializer.deserialize_any(custom_ds)?;
-    res.generate_publication_topic_data().map_err(|e| de::Error::custom(e))
+    res
+      .generate_publication_topic_data()
+      .map_err(|e| de::Error::custom(e))
   }
 }
 
@@ -571,11 +576,9 @@ impl Serialize for PublicationBuiltinTopicData_Key {
   }
 }
 
-
 // =======================================================================
 // =======================================================================
 // =======================================================================
-
 
 /// Type specified in RTPS v2.3 spec Figure 8.30
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -587,7 +590,7 @@ pub struct DiscoveredWriterData {
 }
 
 // separate type is needed to serialize correctly
-#[derive(Eq,PartialEq,Ord,PartialOrd,Debug, Clone, Copy, Hash)]
+#[derive(Eq, PartialEq, Ord, PartialOrd, Debug, Clone, Copy, Hash)]
 pub struct DiscoveredWriterData_Key(pub GUID); // wrapper to enable custom PL CDR (de)serialization
 
 impl Key for DiscoveredWriterData_Key {}
@@ -596,7 +599,7 @@ impl Keyed for DiscoveredWriterData {
   type K = DiscoveredWriterData_Key;
 
   fn get_key(&self) -> Self::K {
-    DiscoveredWriterData_Key( self.publication_topic_data.key )
+    DiscoveredWriterData_Key(self.publication_topic_data.key)
   }
 }
 
@@ -640,7 +643,8 @@ impl<'de> Deserialize<'de> for DiscoveredWriterData {
   {
     let custom_ds = BuiltinDataDeserializer::new();
     let res = deserializer.deserialize_any(custom_ds)?;
-    res.generate_discovered_writer_data()
+    res
+      .generate_discovered_writer_data()
       .map_err(|e| de::Error::custom(e))
   }
 }
@@ -662,7 +666,8 @@ impl<'de> Deserialize<'de> for DiscoveredWriterData_Key {
   {
     let custom_ds = BuiltinDataDeserializer::new();
     let res = deserializer.deserialize_any(custom_ds)?;
-    res.generate_discovered_writer_data_key()
+    res
+      .generate_discovered_writer_data_key()
       .map_err(|e| de::Error::custom(e))
   }
 }
@@ -676,7 +681,6 @@ impl Serialize for DiscoveredWriterData_Key {
     builtin_data_serializer.serialize_key::<S>(serializer, true)
   }
 }
-
 
 // =======================================================================
 // =======================================================================
@@ -699,6 +703,25 @@ pub struct TopicBuiltinTopicData {
   pub history: Option<History>,
   pub resource_limits: Option<ResourceLimits>,
   pub ownership: Option<Ownership>,
+}
+
+impl HasQoSPolicy for TopicBuiltinTopicData {
+  fn get_qos(&self) -> QosPolicies {
+    QosPolicies {
+      durability: self.durability,
+      deadline: self.deadline,
+      latency_budget: self.latency_budget,
+      ownership: self.ownership,
+      liveliness: self.liveliness,
+      time_based_filter: None,
+      reliability: self.reliability,
+      lifespan: self.lifespan,
+      destination_order: self.destination_order,
+      presentation: self.presentation,
+      history: self.history,
+      resource_limits: self.resource_limits,
+    }
+  }
 }
 
 impl<'de> Deserialize<'de> for TopicBuiltinTopicData {
@@ -727,8 +750,9 @@ impl Serialize for TopicBuiltinTopicData {
 // =======================================================================
 
 /// DDS Spec defined DiscoveredTopicData with extra updated time attribute.
-/// Practically this is gotten from [DomainParticipant](../participant/struct.DomainParticipant.html) during runtime
-/// Type specified in RTPS v2.3 spec Figure 8.30
+/// Practically this is gotten from
+/// [DomainParticipant](../participant/struct.DomainParticipant.html) during
+/// runtime Type specified in RTPS v2.3 spec Figure 8.30
 #[derive(Debug, PartialEq, Clone)]
 pub struct DiscoveredTopicData {
   pub updated_time: u64,
@@ -759,7 +783,9 @@ impl<'de> Deserialize<'de> for DiscoveredTopicData {
   {
     let custom_ds = BuiltinDataDeserializer::new();
     let res = deserializer.deserialize_any(custom_ds)?;
-    let topic_data = res.generate_topic_data().map_err(|e| de::Error::custom(e))?;
+    let topic_data = res
+      .generate_topic_data()
+      .map_err(|e| de::Error::custom(e))?;
 
     Ok(DiscoveredTopicData::new(topic_data))
   }
@@ -779,7 +805,8 @@ impl Keyed for DiscoveredTopicData {
   type K = GUID;
 
   fn get_key(&self) -> Self::K {
-    // topic should always have a name, if this crashes the problem is in the overall logic (or message parsing)
+    // topic should always have a name, if this crashes the problem is in the
+    // overall logic (or message parsing)
     match self.topic_data.key {
       Some(k) => k,
       None => GUID::GUID_UNKNOWN,
@@ -820,7 +847,7 @@ pub struct ParticipantMessageData {
   pub guid: GuidPrefix,
   pub kind: ParticipantMessageDataKind,
   // normally this should be empty
-  //pub length: u32, // encoding the length is implicit in the CDR encoding of Vec
+  // pub length: u32, // encoding the length is implicit in the CDR encoding of Vec
   pub data: Vec<u8>,
 }
 
@@ -842,14 +869,14 @@ impl Key for (GuidPrefix, ParticipantMessageDataKind) {}
 mod tests {
   use super::*;
 
-  //use crate::serialization::cdr_serializer::to_little_endian_binary;
+  // use crate::serialization::cdr_serializer::to_little_endian_binary;
   use crate::serialization::{
     Message,
     cdr_serializer::{to_bytes},
   };
   use byteorder::LittleEndian;
   use bytes::Bytes;
-    use log::info;
+  use log::info;
   use crate::serialization::pl_cdr_deserializer::PlCdrDeserializerAdapter;
 
   use crate::{
@@ -1018,6 +1045,6 @@ mod tests {
   //   )
   //   .unwrap();
 
-  //   let _data2 = to_bytes::<ParticipantMessageData, LittleEndian>(&rpi).unwrap();
-  // }
+  //   let _data2 = to_bytes::<ParticipantMessageData,
+  // LittleEndian>(&rpi).unwrap(); }
 }


### PR DESCRIPTION
Attempting to implement the find_topic method discussed in #9. I'm looking for advice because I'm unsure of several things.

- I changed the return type to be `Result<Option<Topic>>` because I imagine the `Topic` name may not exist. I do not know if this is correct or acceptable.
- It's unclear how `DomainParticipant_Inner` can create a `Topic` without a reference to `DomainParticipantWeak`, as suggested by the method `create_topic`, so I added an argument for such reference. I do not know if this is correct or acceptable.
- I basically found myself constructing a `QosPolicies` for `TopicBuiltinTopicData` so I just went ahead and implemented the `HasQoSPolicy` trait for it. I do not know if this is acceptable.
- I see the repo has a `rustfmt.toml` file for formatting so I assume that it is desirable to have the files formatted using those rules, however, the two files I edited for this PR had many formatting changes. If this is unacceptable and I can revert the formatting changes.