### PR TITLE
functions which use strings should ask for what they need

### DIFF
--- a/examples/ros2_demo/turtle_listener.rs
+++ b/examples/ros2_demo/turtle_listener.rs
@@ -34,7 +34,7 @@ impl TurtleListener {
 
     let turtle_cmd_vel_topic = ros_node.create_ros_topic(
       &TurtleCmdVelTopic::topic_name(),
-      &TurtleCmdVelTopic::type_name(),
+      TurtleCmdVelTopic::type_name(),
       TurtleCmdVelTopic::get_qos(),
       TurtleCmdVelTopic::topic_kind(),
     )

--- a/examples/ros2_demo/turtle_sender.rs
+++ b/examples/ros2_demo/turtle_sender.rs
@@ -33,7 +33,7 @@ impl TurtleSender {
 
     let turtle_cmd_vel_topic = ros_node.create_ros_topic(
       &TurtleCmdVelTopic::topic_name(),
-      &TurtleCmdVelTopic::type_name(),
+      TurtleCmdVelTopic::type_name(),
       TurtleCmdVelTopic::get_qos(),
       TurtleCmdVelTopic::topic_kind(),
     )

--- a/examples/shapes_demo/main.rs
+++ b/examples/shapes_demo/main.rs
@@ -105,11 +105,11 @@ fn event_loop(running_flag: Arc<AtomicBool>, domain_id: u16) {
 
   // declare topics, subscriber, publisher, readers and writers
   let square_topic = domain_participant
-    .create_topic("Square", "ShapeType", &pub_qos, TopicKind::WithKey)
+    .create_topic("Square".to_string(), "ShapeType".to_string(), &pub_qos, TopicKind::WithKey)
     .unwrap();
   //println!("Square");
   let triangle_topic = domain_participant
-    .create_topic("Triangle", "ShapeType", &pub_qos, TopicKind::WithKey)
+    .create_topic("Triangle".to_string(), "ShapeType".to_string(), &pub_qos, TopicKind::WithKey)
     .unwrap();
   //println!("Triangle. Have topics. Create subscriber.");
 

--- a/src/dds/dp_event_loop.rs
+++ b/src/dds/dp_event_loop.rs
@@ -656,8 +656,8 @@ impl DPEventLoop {
               Some(_) => TopicKind::WithKey,
               None => TopicKind::NoKey,
             };
-            ddsc.add_new_topic(&topic.topic_data.name, topic_kind,
-               TypeDesc::new(&topic.topic_data.type_name));
+            ddsc.add_new_topic(topic.topic_data.name.clone(), topic_kind,
+               TypeDesc::new(topic.topic_data.type_name.clone()));
           }
         }
         _ => panic!("DDSCache is poisoned"),

--- a/src/dds/message_receiver.rs
+++ b/src/dds/message_receiver.rs
@@ -443,9 +443,9 @@ use super::*;
 
     let dds_cache = Arc::new(RwLock::new(DDSCache::new()));
     dds_cache.write().unwrap().add_new_topic(
-      &"test".to_string(),
+      "test".to_string(),
       TopicKind::NoKey,
-      TypeDesc::new("testi"),
+      TypeDesc::new("testi".to_string()),
     );
     let reader_ing = ReaderIngredients {
       guid: new_guid,

--- a/src/dds/no_key/datawriter.rs
+++ b/src/dds/no_key/datawriter.rs
@@ -448,7 +448,7 @@ mod tests {
       .create_publisher(&qos)
       .expect("Failed to create publisher");
     let topic = domain_participant
-      .create_topic("Aasii", "Huh?", &qos, TopicKind::NoKey)
+      .create_topic("Aasii".to_string(), "Huh?".to_string(), &qos, TopicKind::NoKey)
       .expect("Failed to create topic");
 
     let data_writer: DataWriter<RandomData, CDRSerializerAdapter<RandomData, LittleEndian>> =
@@ -483,7 +483,7 @@ mod tests {
       .create_publisher(&qos)
       .expect("Failed to create publisher");
     let topic = domain_participant
-      .create_topic("Aasii", "Huh?", &qos, TopicKind::NoKey)
+      .create_topic("Aasii".to_string(), "Huh?".to_string(), &qos, TopicKind::NoKey)
       .expect("Failed to create topic");
 
     let data_writer: DataWriter<RandomData, CDRSerializerAdapter<RandomData, LittleEndian>> =

--- a/src/dds/participant.rs
+++ b/src/dds/participant.rs
@@ -179,8 +179,8 @@ impl DomainParticipant {
   /// ```
   pub fn create_topic(
     &self,
-    name: &str,
-    type_desc: &str,
+    name: String,
+    type_desc: String,
     qos: &QosPolicies,
     topic_kind: TopicKind,
   ) -> Result<Topic> {
@@ -312,8 +312,8 @@ impl DomainParticipantWeak {
 
   pub fn create_topic(
     &self,
-    name: &str,
-    type_desc: &str,
+    name: String,
+    type_desc: String,
     qos: &QosPolicies,
     topic_kind: TopicKind,
   ) -> Result<Topic> {
@@ -428,8 +428,8 @@ impl DomainParticipant_Disc {
   pub fn create_topic(
     &self,
     dp: &DomainParticipantWeak,
-    name: &str,
-    type_desc: &str,
+    name: String,
+    type_desc: String,
     qos: &QosPolicies,
     topic_kind: TopicKind,
   ) -> Result<Topic> {
@@ -764,14 +764,14 @@ impl DomainParticipant_Inner {
   pub fn create_topic(
     &self,
     domain_participant_weak: &DomainParticipantWeak,
-    name: &str,
-    type_desc: &str,
+    name: String,
+    type_desc: String,
     qos: &QosPolicies,
     topic_kind: TopicKind,
   ) -> Result<Topic> {
     let topic = Topic::new(
       domain_participant_weak,
-      name.to_string(),
+      name,
       TypeDesc::new(type_desc),
       &qos,
       topic_kind,
@@ -821,7 +821,7 @@ impl DomainParticipant_Inner {
         let name = d.get_topic_name().clone();
         let type_desc = d.topic_data.type_name.clone();
         let topic =
-          self.create_topic(domain_participant_weak, &name, &type_desc, &qos, topic_kind)?;
+          self.create_topic(domain_participant_weak, name, type_desc, &qos, topic_kind)?;
         Ok(Some(topic))
       }
       None => Ok(None),
@@ -951,7 +951,7 @@ mod tests {
       .expect("Failed to create publisher");
 
     let topic = domain_participant
-      .create_topic("Aasii", "RandomData", &qos.clone(), TopicKind::WithKey)
+      .create_topic("Aasii".to_string(), "RandomData".to_string(), &qos.clone(), TopicKind::WithKey)
       .expect("Failed to create topic");
 
     let mut _data_writer = publisher
@@ -972,7 +972,7 @@ mod tests {
       .expect("Failed to create publisher");
 
     let topic = domain_participant
-      .create_topic("Aasii", "Huh?", &qos.clone(), TopicKind::WithKey)
+      .create_topic("Aasii".to_string(), "Huh?".to_string(), &qos.clone(), TopicKind::WithKey)
       .expect("Failed to create topic");
 
     let mut _data_writer = publisher

--- a/src/dds/pubsub.rs
+++ b/src/dds/pubsub.rs
@@ -11,12 +11,8 @@ use serde::{Serialize, de::DeserializeOwned};
 
 use byteorder::{LittleEndian};
 
-use crate::{
-  discovery::discovery::DiscoveryCommand,
-  structure::{guid::GUID, entity::RTPSEntity, guid::EntityId},
-};
+use crate::{discovery::discovery::DiscoveryCommand, log_and_err_precondition_not_met, structure::{guid::GUID, entity::RTPSEntity, guid::EntityId}};
 
-use crate::log_and_err_precondition_not_met;
 use crate::dds::{
   values::result::*,
   data_types::EntityKind,
@@ -855,8 +851,9 @@ impl InnerSubscriber {
 
     let dp = match self.get_participant() {
         Some(dp) => dp,
-        None => return 
-          log_and_err_precondition_not_met!("DomainParticipant doesn't exist anymore.") ,
+        None => {
+          return log_and_err_precondition_not_met!("DomainParticipant doesn't exist anymore.")
+        }
       };
 
     let reader_guid = GUID::new_with_prefix_and_id(dp.get_guid_prefix(), reader_id);
@@ -893,7 +890,7 @@ impl InnerSubscriber {
     match dp.get_dds_cache().write() {
       Ok(mut dds_cache) => {
         dds_cache.add_new_topic(
-            &topic.get_name(),
+            topic.get_name(),
             topic.kind(),
             topic.get_type(),
           );                   

--- a/src/dds/reader.rs
+++ b/src/dds/reader.rs
@@ -1001,9 +1001,9 @@ mod tests {
 
     let dds_cache = Arc::new(RwLock::new(DDSCache::new()));
     dds_cache.write().unwrap().add_new_topic(
-      &"test".to_string(),
+      "test".to_string(),
       TopicKind::NoKey,
-      TypeDesc::new("testi"),
+      TypeDesc::new("testi".to_string()),
     );
 
     let reader_ing = ReaderIngredients {
@@ -1055,9 +1055,9 @@ mod tests {
 
     let dds_cache = Arc::new(RwLock::new(DDSCache::new()));
     dds_cache.write().unwrap().add_new_topic(
-      &"test".to_string(),
+      "test".to_string(),
       TopicKind::NoKey,
-      TypeDesc::new("testi"),
+      TypeDesc::new("testi".to_string()),
     );
 
     let reader_ing = ReaderIngredients {
@@ -1119,9 +1119,9 @@ mod tests {
 
     let dds_cache = Arc::new(RwLock::new(DDSCache::new()));
     dds_cache.write().unwrap().add_new_topic(
-      &"test".to_string(),
+      "test".to_string(),
       TopicKind::NoKey,
-      TypeDesc::new("testi"),
+      TypeDesc::new("testi".to_string()),
     );
     let reader_ing = ReaderIngredients {
       guid: new_guid,
@@ -1254,9 +1254,9 @@ mod tests {
 
     let dds_cache = Arc::new(RwLock::new(DDSCache::new()));
     dds_cache.write().unwrap().add_new_topic(
-      &"test".to_string(),
+      "test".to_string(),
       TopicKind::NoKey,
-      TypeDesc::new("testi"),
+      TypeDesc::new("testi".to_string()),
     );
 
     let reader_ing = ReaderIngredients {

--- a/src/dds/typedesc.rs
+++ b/src/dds/typedesc.rs
@@ -5,8 +5,8 @@ pub struct TypeDesc {
 } // placeholders
 
 impl TypeDesc {
-  pub fn new(my_name: &str) -> TypeDesc {
-    TypeDesc { my_name: my_name.to_string() }
+  pub fn new(my_name: String) -> TypeDesc {
+    TypeDesc { my_name }
   }
   pub fn name(&self) -> &str {
     &self.my_name

--- a/src/dds/values/result.rs
+++ b/src/dds/values/result.rs
@@ -58,14 +58,14 @@ pub enum Error {
 
 
 impl Error {
-  pub fn bad_parameter<T>(reason: &str) -> Result<T> 
+  pub fn bad_parameter<T>(reason: impl Into<String>) -> Result<T> 
   { 
-    Err( Error::BadParameter{ reason: reason.to_string() }) 
+    Err( Error::BadParameter{ reason: reason.into() }) 
   }
 
-  pub fn precondition_not_met<T>(precondition: &str) -> Result<T> 
+  pub fn precondition_not_met<T>(precondition: impl Into<String>) -> Result<T> 
   { 
-    Err( Error::PreconditionNotMet{ precondition: precondition.to_string() }) 
+    Err( Error::PreconditionNotMet{ precondition: precondition.into() }) 
   }
   
 }

--- a/src/dds/with_key/datareader.rs
+++ b/src/dds/with_key/datareader.rs
@@ -1211,7 +1211,7 @@ mod tests {
 
     let sub = dp.create_subscriber(&qos).unwrap();
     let topic = dp
-      .create_topic("dr", "drtest?", &qos, TopicKind::WithKey)
+      .create_topic("dr".to_string(), "drtest?".to_string(), &qos, TopicKind::WithKey)
       .unwrap();
 
     let (send, _rec) = mio_channel::sync_channel::<()>(10);
@@ -1331,7 +1331,7 @@ mod tests {
 
     let sub = dp.create_subscriber(&qos).unwrap();
     let topic = dp
-      .create_topic("dr read", "read fn test?", &qos, TopicKind::WithKey)
+      .create_topic("dr read".to_string(), "read fn test?".to_string(), &qos, TopicKind::WithKey)
       .unwrap();
 
     let (send, _rec) = mio_channel::sync_channel::<()>(10);
@@ -1557,7 +1557,7 @@ mod tests {
 
     let sub = dp.create_subscriber(&qos).unwrap();
     let topic = dp
-      .create_topic("wakeup", "Wake up!", &qos, TopicKind::WithKey)
+      .create_topic("wakeup".to_string(), "Wake up!".to_string(), &qos, TopicKind::WithKey)
       .unwrap();
 
     let (send, rec) = mio_channel::sync_channel::<()>(10);

--- a/src/dds/with_key/datawriter.rs
+++ b/src/dds/with_key/datawriter.rs
@@ -148,7 +148,7 @@ where
 
     match dds_cache.write() {
       Ok(mut cache) => cache.add_new_topic(
-        &topic.get_name(),
+        topic.get_name(),
         TopicKind::NoKey,
         topic.get_type(),
       ),
@@ -910,7 +910,7 @@ mod tests {
       .create_publisher(&qos)
       .expect("Failed to create publisher");
     let topic = domain_participant
-      .create_topic("Aasii", "Huh?", &qos, TopicKind::WithKey)
+      .create_topic("Aasii".to_string(), "Huh?".to_string(), &qos, TopicKind::WithKey)
       .expect("Failed to create topic");
 
     let data_writer: DataWriter<RandomData, CDRSerializerAdapter<RandomData, LittleEndian>> =
@@ -945,7 +945,7 @@ mod tests {
       .create_publisher(&qos)
       .expect("Failed to create publisher");
     let topic = domain_participant
-      .create_topic("Aasii", "Huh?", &qos, TopicKind::WithKey)
+      .create_topic("Aasii".to_string(), "Huh?".to_string(), &qos, TopicKind::WithKey)
       .expect("Failed to create topic");
 
     let data_writer: DataWriter<RandomData, CDRSerializerAdapter<RandomData, LittleEndian>> =
@@ -981,7 +981,7 @@ mod tests {
       .create_publisher(&qos)
       .expect("Failed to create publisher");
     let topic = domain_participant
-      .create_topic("Aasii", "Huh?", &qos, TopicKind::WithKey)
+      .create_topic("Aasii".to_string(), "Huh?".to_string(), &qos, TopicKind::WithKey)
       .expect("Failed to create topic");
 
     let data_writer: DataWriter<RandomData, CDRSerializerAdapter<RandomData, LittleEndian>> =

--- a/src/dds/writer.rs
+++ b/src/dds/writer.rs
@@ -972,7 +972,7 @@ mod tests {
       .create_publisher(&qos)
       .expect("Failed to create publisher");
     let topic = domain_participant
-      .create_topic("Aasii", "Huh?", &qos, TopicKind::WithKey)
+      .create_topic("Aasii".to_string(), "Huh?".to_string(), &qos, TopicKind::WithKey)
       .expect("Failed to create topic");
     let data_writer: DataWriter<RandomData, CDRSerializerAdapter<RandomData, LittleEndian>> =
       publisher

--- a/src/discovery/data_types/topic_data.rs
+++ b/src/discovery/data_types/topic_data.rs
@@ -124,15 +124,15 @@ pub struct SubscriptionBuiltinTopicData {
 impl SubscriptionBuiltinTopicData {
   pub fn new(
     key: GUID,
-    topic_name: &str,
-    type_name: &str,
+    topic_name: String,
+    type_name: String,
     qos: &QosPolicies,
   ) -> SubscriptionBuiltinTopicData {
     let mut sbtd = SubscriptionBuiltinTopicData {
       key,
       participant_key: None,
-      topic_name: topic_name.to_string(),
-      type_name: type_name.to_string(),
+      topic_name,
+      type_name,
       durability: None,
       deadline: None,
       latency_budget: None,
@@ -310,8 +310,8 @@ impl DiscoveredReaderData {
     let reader_proxy = ReaderProxy::new(reader.get_guid());
     let mut subscription_topic_data = SubscriptionBuiltinTopicData::new(
       reader.get_guid(),
-      &topic.get_name(),
-      &topic.get_type().name().to_string(),
+      topic.get_name(),
+      topic.get_type().name().to_string(),
       &topic.get_qos(),
     );
     subscription_topic_data.set_participant_key(dp.get_guid());
@@ -323,7 +323,7 @@ impl DiscoveredReaderData {
     }
   }
 
-  pub fn default(topic_name: &str, type_name: &str) -> DiscoveredReaderData {
+  pub fn default(topic_name: String, type_name: String) -> DiscoveredReaderData {
     let rguid = GUID::dummy_test_guid(EntityKind::READER_WITH_KEY_BUILT_IN);
     let reader_proxy = ReaderProxy::new(rguid);
     let subscription_topic_data = SubscriptionBuiltinTopicData::new(
@@ -486,14 +486,14 @@ impl PublicationBuiltinTopicData {
   pub fn new(
     guid: GUID,
     participant_guid: GUID,
-    topic_name: &str,
-    type_name: &str,
+    topic_name: String,
+    type_name: String,
   ) -> PublicationBuiltinTopicData {
     PublicationBuiltinTopicData {
       key: guid,
       participant_key: Some(participant_guid),
-      topic_name: topic_name.to_string(),
-      type_name: type_name.to_string(),
+      topic_name,
+      type_name,
       durability: None,
       deadline: None,
       latency_budget: None,
@@ -616,8 +616,8 @@ impl DiscoveredWriterData {
     let mut publication_topic_data = PublicationBuiltinTopicData::new(
       writer.get_guid(),
       dp.get_guid(),
-      &topic.get_name(),
-      &topic.get_type().name().to_string(),
+      topic.get_name(),
+      topic.get_type().name().to_string(),
     );
 
     publication_topic_data.read_qos(&topic.get_qos());

--- a/src/discovery/discovery.rs
+++ b/src/discovery/discovery.rs
@@ -212,8 +212,8 @@ impl Discovery {
     // Participant
     let dcps_participant_topic = try_construct!(
       domain_participant.create_topic(
-        "DCPSParticipant",
-        "SPDPDiscoveredParticipantData",
+        "DCPSParticipant".to_string(),
+        "SPDPDiscoveredParticipantData".to_string(),
         &Discovery::create_spdp_patricipant_qos(),
         TopicKind::WithKey,
       ),
@@ -266,8 +266,8 @@ impl Discovery {
     // Subscriptions: What are the Readers on the network and what are they subscribing to?
 
     let dcps_subscription_topic = try_construct!( domain_participant.create_topic(
-      "DCPSSubscription",
-      "DiscoveredReaderData",
+      "DCPSSubscription".to_string(),
+      "DiscoveredReaderData".to_string(),
       &discovery_subscriber_qos,
       TopicKind::WithKey,
     ) ,"Unable to create DCPSSubscription topic. {:?}");
@@ -307,8 +307,8 @@ impl Discovery {
     // Publication : Who are thr Writers?
 
     let dcps_publication_topic = try_construct!( domain_participant.create_topic(
-      "DCPSPublication",
-      "DiscoveredWriterData",
+      "DCPSPublication".to_string(),
+      "DiscoveredWriterData".to_string(),
       &discovery_publisher_qos,
       TopicKind::WithKey,
     ) ,"Unable to create DCPSPublication topic. {:?}");
@@ -347,8 +347,8 @@ impl Discovery {
     // Topic topic (not a typo)
 
     let dcps_topic_topic = try_construct!( domain_participant.create_topic(
-      "DCPSTopic",
-      "DiscoveredTopicData",
+      "DCPSTopic".to_string(),
+      "DiscoveredTopicData".to_string(),
       &QosPolicyBuilder::new().build(), //TODO: check what this should be
       TopicKind::WithKey,
     ) ,"Unable to create DCPSTopic topic. {:?}");
@@ -398,8 +398,8 @@ impl Discovery {
     // Participant Message Data 8.4.13
 
     let participant_message_topic = try_construct!( domain_participant.create_topic(
-      "DCPSParticipantMessage",
-      "ParticipantMessageData",
+      "DCPSParticipantMessage".to_string(),
+      "ParticipantMessageData".to_string(),
       &Discovery::PARTICIPANT_MESSAGE_QOS,
       TopicKind::WithKey,
     ) ,"Unable to create DCPSParticipantMessage topic. {:?}");
@@ -682,8 +682,8 @@ impl Discovery {
 
     let sub_topic_data = SubscriptionBuiltinTopicData::new(
       reader_guid,
-      &String::from("DCPSParticipant"),
-      &String::from("SPDPDiscoveredParticipantData"),
+      String::from("DCPSParticipant"),
+      String::from("SPDPDiscoveredParticipantData"),
       &Discovery::create_spdp_patricipant_qos(),
     );
     let drd = DiscoveredReaderData {
@@ -704,8 +704,8 @@ impl Discovery {
     let pub_topic_data = PublicationBuiltinTopicData::new(
       writer_guid,
       dp.get_guid(),
-      &String::from("DCPSParticipant"),
-      &String::from("SPDPDiscoveredParticipantData"),
+      String::from("DCPSParticipant"),
+      String::from("SPDPDiscoveredParticipantData"),
     );
     let dwd = DiscoveredWriterData {
       last_updated: Instant::now(),
@@ -1275,8 +1275,8 @@ mod tests {
 
     let topic = participant
       .create_topic(
-        "Square",
-        "ShapeType",
+        "Square".to_string(),
+        "ShapeType".to_string(),
         &QosPolicies::qos_none(),
         TopicKind::WithKey,
       )
@@ -1361,8 +1361,8 @@ mod tests {
 
     let topic = participant
       .create_topic(
-        "Square",
-        "ShapeType",
+        "Square".to_string(),
+        "ShapeType".to_string(),
         &QosPolicies::qos_none(),
         TopicKind::WithKey,
       )

--- a/src/discovery/discovery_db.rs
+++ b/src/discovery/discovery_db.rs
@@ -416,8 +416,8 @@ impl DiscoveryDB {
 
     let mut subscription_data = SubscriptionBuiltinTopicData::new(
       reader_guid,
-      &topic.get_name(),
-      topic.get_type().name(),
+      topic.get_name(),
+      topic.get_type().name().to_string(),
       &topic.get_qos(),
     );
     subscription_data.set_participant_key(domain_participant.get_guid());
@@ -554,7 +554,7 @@ mod tests {
     let _discoverydb = DiscoveryDB::new(GUID::new_particiapnt_guid());
     let topic_name = String::from("some_topic");
     let type_name = String::from("RandomData");
-    let _dreader = DiscoveredReaderData::default(&topic_name, &type_name);
+    let _dreader = DiscoveredReaderData::default(topic_name, type_name);
 
     // TODO: more tests :)
   }
@@ -566,16 +566,16 @@ mod tests {
     let domain_participant = DomainParticipant::new(0).expect("Failed to create publisher");
     let topic = domain_participant
       .create_topic(
-        "Foobar",
-        "RandomData",
+        "Foobar".to_string(),
+        "RandomData".to_string(),
         &QosPolicies::qos_none(),
         TopicKind::WithKey,
       )
       .unwrap();
     let topic2 = domain_participant
       .create_topic(
-        "Barfoo",
-        "RandomData",
+        "Barfoo".to_string(),
+        "RandomData".to_string(),
         &QosPolicies::qos_none(),
         TopicKind::WithKey,
       )
@@ -652,8 +652,8 @@ mod tests {
     let dp = DomainParticipant::new(0).expect("Failed to create participant");
     let topic = dp
       .create_topic(
-        "some topic name",
-        "Wazzup",
+        "some topic name".to_string(),
+        "Wazzup".to_string(),
         &QosPolicies::qos_none(),
         TopicKind::WithKey,
       )

--- a/src/ros2/ros_node.rs
+++ b/src/ros2/ros_node.rs
@@ -129,8 +129,8 @@ impl RosParticipantInner {
   {
 
     let ros_discovery_topic = domain_participant.create_topic(
-        ROSDiscoveryTopic::topic_name(),
-        ROSDiscoveryTopic::type_name(),
+        ROSDiscoveryTopic::topic_name().to_string(),
+        ROSDiscoveryTopic::type_name().to_string(),
         &ROSDiscoveryTopic::get_qos(),
         TopicKind::NoKey,
       )?;
@@ -141,15 +141,15 @@ impl RosParticipantInner {
       domain_participant.create_subscriber(&ROSDiscoveryTopic::get_qos())?;
 
     let ros_parameter_events_topic = domain_participant.create_topic(
-      ParameterEventsTopic::topic_name(),
-      ParameterEventsTopic::type_name(),
+      ParameterEventsTopic::topic_name().to_string(),
+      ParameterEventsTopic::type_name().to_string(),
       &ParameterEventsTopic::get_qos(),
       TopicKind::NoKey,
     )?;
 
     let ros_rosout_topic = domain_participant.create_topic(
-      RosOutTopic::topic_name(),
-      RosOutTopic::type_name(),
+      RosOutTopic::topic_name().to_string(),
+      RosOutTopic::type_name().to_string(),
       &RosOutTopic::get_qos(),
       TopicKind::NoKey,
     )?;
@@ -430,7 +430,7 @@ impl RosNode {
   /// * must have balanced curly braces ({}) when used, i.e. {sub}/foo but not {sub/foo nor /foo}
   pub fn create_ros_topic(&self,
     name: &str,
-    type_name: &str,
+    type_name: String,
     qos: QosPolicies,
     topic_kind: TopicKind,
   ) -> Result<Topic, Error> {
@@ -442,7 +442,7 @@ impl RosNode {
     oname.push_str(name_stripped);
     info!("Creating topic, DDS name: {}",oname);
     let topic = self.ros_participant.domain_participant()
-      .create_topic(&oname, type_name, &qos, topic_kind)?;
+      .create_topic(oname, type_name, &qos, topic_kind)?;
     info!("Created topic");
     Ok(topic)
   }

--- a/src/serialization/builtin_data_deserializer.rs
+++ b/src/serialization/builtin_data_deserializer.rs
@@ -264,13 +264,13 @@ impl BuiltinDataDeserializer {
       None => return Err(Error::Message("Failed to parse key.".to_string())),
     };
 
-    let topic_name: &str = match self.topic_name.as_ref() {
-      Some(tn) => tn,
+    let topic_name = match &self.topic_name {
+      Some(tn) => tn.clone(),
       None => return Err(Error::Message("Failed to parse topic name.".to_string())),
     };
 
-    let type_name: &str = match self.type_name.as_ref() {
-      Some(tn) => tn,
+    let type_name = match &self.type_name {
+      Some(tn) => tn.clone(),
       None => return Err(Error::Message("Failed to parse type name.".to_string())),
     };
 

--- a/src/serialization/builtin_data_serializer.rs
+++ b/src/serialization/builtin_data_serializer.rs
@@ -44,13 +44,13 @@ struct StringData {
 }
 
 impl StringData {
-  pub fn new(parameter_id: ParameterId, string_data: &str) -> StringData {
+  pub fn new(parameter_id: ParameterId, string_data: String) -> StringData {
     let parameter_length = string_data.len() as u16;
     let parameter_length = parameter_length + (4 - parameter_length % 4) + 4;
     StringData {
       parameter_id,
       parameter_length,
-      string_data: string_data.to_string(),
+      string_data,
     }
   }
 }
@@ -947,20 +947,20 @@ impl<'a> BuiltinDataSerializer<'a> {
   }
 
   fn add_topic_name<S: Serializer>(&self, s: &mut S::SerializeStruct) {
-    if let Some(name) = self.topic_name.as_ref() {
+    if let Some(name) = self.topic_name {
       s.serialize_field(
         "topic_name",
-        &StringData::new(ParameterId::PID_TOPIC_NAME, name),
+        &StringData::new(ParameterId::PID_TOPIC_NAME, name.to_string()),
       )
       .unwrap();
     }
   }
 
   fn add_type_name<S: Serializer>(&self, s: &mut S::SerializeStruct) {
-    if let Some(name) = self.type_name.as_ref() {
+    if let Some(name) = self.type_name {
       s.serialize_field(
         "type_name",
-        &StringData::new(ParameterId::PID_TYPE_NAME, name),
+        &StringData::new(ParameterId::PID_TYPE_NAME, name.to_string()),
       )
       .unwrap();
     }

--- a/src/structure/dds_cache.rs
+++ b/src/structure/dds_cache.rs
@@ -40,12 +40,12 @@ impl DDSCache {
 
   pub fn add_new_topic(
     &mut self,
-    topic_name: &str,
+    topic_name: String,
     topic_kind: TopicKind,
     topic_data_type: TypeDesc,
   ) {
     self.topic_caches.insert(
-        topic_name.to_string(),
+        topic_name.clone(),
         TopicCache::new(topic_name, topic_kind, topic_data_type),
       );
   }
@@ -129,9 +129,9 @@ pub struct TopicCache {
 }
 
 impl TopicCache {
-  pub fn new(topic_name: &str, topic_kind: TopicKind, topic_data_type: TypeDesc) -> TopicCache {
+  pub fn new(topic_name: String, topic_kind: TopicKind, topic_data_type: TypeDesc) -> TopicCache {
     TopicCache {
-      topic_name: topic_name.to_string(),
+      topic_name,
       topic_data_type,
       topic_kind,
       topic_qos: QosPolicyBuilder::new().build(),
@@ -301,7 +301,7 @@ mod tests {
   #[test]
   fn create_dds_cache() {
     let cache = Arc::new(RwLock::new(DDSCache::new()));
-    let topic_name = &String::from("ImJustATopic");
+    let topic_name = String::from("ImJustATopic");
     let change1 = CacheChange::new(
       GUID::GUID_UNKNOWN,
       SequenceNumber::from(1),
@@ -310,24 +310,24 @@ mod tests {
     cache.write().unwrap().add_new_topic(
       topic_name,
       TopicKind::WithKey,
-      TypeDesc::new("IDontKnowIfThisIsNecessary"),
+      TypeDesc::new("IDontKnowIfThisIsNecessary".to_string()),
     );
     cache
       .write()
       .unwrap()
-      .to_topic_add_change(topic_name, &DDSTimestamp::now(), change1);
+      .to_topic_add_change(&topic_name, &DDSTimestamp::now(), change1);
 
     let pointerToCache1 = cache.clone();
 
     thread::spawn(move || {
-      let topic_name = &String::from("ImJustATopic");
+      let topic_name = String::from("ImJustATopic");
       let cahange2 = CacheChange::new(
         GUID::GUID_UNKNOWN,
         SequenceNumber::from(1),
         DDSData::new(SerializedPayload::default()),
       );
       pointerToCache1.write().unwrap().to_topic_add_change(
-        topic_name,
+        &topic_name,
         &DDSTimestamp::now(),
         cahange2,
       );
@@ -337,7 +337,7 @@ mod tests {
         DDSData::new(SerializedPayload::default()),
       );
       pointerToCache1.write().unwrap().to_topic_add_change(
-        topic_name,
+        &topic_name,
         &DDSTimestamp::now(),
         cahange3,
       );
@@ -348,13 +348,13 @@ mod tests {
     cache
       .read()
       .unwrap()
-      .from_topic_get_change(topic_name, &DDSTimestamp::now());
+      .from_topic_get_change(&topic_name, &DDSTimestamp::now());
     assert_eq!(
       cache
         .read()
         .unwrap()
         .from_topic_get_changes_in_range(
-          topic_name,
+          &topic_name,
           &(DDSTimestamp::now() - DDSDuration::from_secs(23)),
           &DDSTimestamp::now()
         )

--- a/src/test/test_data.rs
+++ b/src/test/test_data.rs
@@ -266,7 +266,7 @@ pub(crate) fn subscription_builtin_topic_data() -> Option<SubscriptionBuiltinTop
     .build();
 
   let sub_topic_data =
-    SubscriptionBuiltinTopicData::new(GUID::dummy_test_guid(EntityKind::WRITER_NO_KEY_USER_DEFINED), "some topic name", "RandomData", &qos);
+    SubscriptionBuiltinTopicData::new(GUID::dummy_test_guid(EntityKind::WRITER_NO_KEY_USER_DEFINED), "some topic name".to_string(), "RandomData".to_string(), &qos);
 
   Some(sub_topic_data)
 }


### PR DESCRIPTION
there are a great many functions which accept `&str`/`&String` as an arg, and then immediately convert it to a `String`. This means an allocation *always* occurs. A better approach is to take `String` as an arg and let the calling code decide how to construct it. In many cases this eliminates the allocation, since the calling code already has a `String` it can move into the function.

I could use change the method signatures to `impl Into<String>` which can then accept either a `&str` or a `String`. Except for the `Error` type, I haven't done this because i think this way is more explicit. Would like to get your thoughts on that though

There may well be better approaches again. By introducing lifetimes to some of the helper types, you might be able to simply pass `&'a str` around, But i think that's a slightly bigger change than what i've done here