### PR TITLE
allow large enum variant

### DIFF
--- a/src/network/constant.rs
+++ b/src/network/constant.rs
@@ -98,6 +98,7 @@ pub enum TimerMessageType {
 }
 
 #[derive(Debug)]
+#[allow(clippy::large_enum_variant)]
 pub(crate) enum DiscoveryNotificationType {
   ReaderUpdated { 
     rtps_reader_proxy: RtpsReaderProxy,


### PR DESCRIPTION
fixes the build errors in the clippy job.

There's a large difference between the size of the largest and second largest variants of this enum. In those situations, clippy will suggest boxing the largest one. That will involve a heap allocation, but will also make the enum dramatically smaller.

i would say boxing is the right strategy if the variant is not that "common". For now i've just 'allowed' the lint.

Whichever you prefer.

(there's a reference for this lint here - https://rust-lang.github.io/rust-clippy/master/index.html#large_enum_variant)