### PR TITLE
Add pub fn sub_duration for Timestamp

### DIFF
--- a/src/structure/time.rs
+++ b/src/structure/time.rs
@@ -69,6 +69,9 @@ impl Timestamp {
   pub fn duration_since(&self, since: Timestamp) -> Duration {
     *self - since
   }
+  pub fn sub_duration(&self, duration: Duration) -> Timestamp {
+    *self - duration
+  }
 }
 
 impl Sub for Timestamp {


### PR DESCRIPTION
Add `pub fn sub_duration` for `Timestamp`, so that one can obtain and use a timestamp with a certain offset to the system timestamp.