### PR TITLE
Add unicast_socket binding with errors ignored (for windows only)

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,6 +34,8 @@ socket2 = { version = "0.4", features = ["all"] }
 bytes = "1"
 static_assertions = "1.1"
 thiserror = "1.0.29"
+local-ip-address = "0.4.4"
+
 
 [dev-dependencies]
 serde_repr = {version = "0.1" }


### PR DESCRIPTION
properly ignoring binding errors may be helpful in preventing programs from panics, just in case of that windows sometimes retains invalid network interfaces in history.