### PR TITLE
Refactor/locator

### DIFF
--- a/src/dds/message_receiver.rs
+++ b/src/dds/message_receiver.rs
@@ -15,7 +15,7 @@ use crate::{
   structure::{
     entity::RTPSEntity,
     guid::{EntityId, GuidPrefix, GUID},
-    locator::{Locator, LocatorKind},
+    locator::Locator,
     time::Timestamp,
   },
 };
@@ -59,9 +59,6 @@ impl MessageReceiver {
     participant_guid_prefix: GuidPrefix,
     acknack_sender: mio_channel::SyncSender<(GuidPrefix, AckSubmessage)>,
   ) -> MessageReceiver {
-    // could be passed in as a parameter
-    let locator_kind = LocatorKind::LOCATOR_KIND_UDP_V4;
-
     MessageReceiver {
       available_readers: BTreeMap::new(),
       acknack_sender,
@@ -71,16 +68,8 @@ impl MessageReceiver {
       source_vendor_id: VendorId::VENDOR_UNKNOWN,
       source_guid_prefix: GuidPrefix::GUIDPREFIX_UNKNOWN,
       dest_guid_prefix: GuidPrefix::GUIDPREFIX_UNKNOWN,
-      unicast_reply_locator_list: vec![Locator {
-        kind: locator_kind,
-        address: Locator::LOCATOR_ADDRESS_INVALID,
-        port: Locator::LOCATOR_PORT_INVALID,
-      }],
-      multicast_reply_locator_list: vec![Locator {
-        kind: locator_kind,
-        address: Locator::LOCATOR_ADDRESS_INVALID,
-        port: Locator::LOCATOR_PORT_INVALID,
-      }],
+      unicast_reply_locator_list: vec![Locator::Invalid],
+      multicast_reply_locator_list: vec![Locator::Invalid],
       timestamp: None,
 
       pos: 0,

--- a/src/dds/participant.rs
+++ b/src/dds/participant.rs
@@ -891,7 +891,10 @@ impl std::fmt::Debug for DomainParticipant {
 
 #[cfg(test)]
 mod tests {
-  use std::{collections::BTreeSet, net::SocketAddr};
+  use std::{
+    collections::BTreeSet,
+    net::{Ipv4Addr, SocketAddr, SocketAddrV4},
+  };
 
   use enumflags2::BitFlags;
   use log::info;
@@ -911,7 +914,7 @@ mod tests {
     serialization::{cdr_serializer::CDRSerializerAdapter, submessage::*, Message, SubMessage},
     structure::{
       guid::{EntityId, GUID},
-      locator::{Locator, LocatorKind},
+      locator::Locator,
       sequence_number::{SequenceNumber, SequenceNumberSet},
     },
     test::random_data::RandomData,
@@ -1013,17 +1016,9 @@ mod tests {
     m.add_submessage(s);
     let _data: Vec<u8> = m.write_to_vec_with_ctx(Endianness::LittleEndian).unwrap();
     info!("data to send via udp: {:?}", _data);
-    let loca = Locator {
-      kind: LocatorKind::LOCATOR_KIND_UDP_V4,
-      port: port_number as u32,
-      address: [
-        0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
-        0x00,
-      ],
-      /* address: [0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x7F,
-       * 0x00, 0x00, 0x01], */
-    };
-    let locas = vec![loca];
-    sender.send_to_locator_list(&_data, &locas);
+    let ip = Ipv4Addr::from([0x00, 0x00, 0x00, 0x00]);
+    let socket_address = SocketAddrV4::new(ip, port_number);
+    let locators = vec![Locator::UdpV4(socket_address)];
+    sender.send_to_locator_list(&_data, &locators);
   }
 }

--- a/src/serialization/builtin_data_serializer.rs
+++ b/src/serialization/builtin_data_serializer.rs
@@ -32,7 +32,7 @@ use crate::{
     duration::{Duration, DurationData},
     endpoint::ReliabilityKind,
     guid::{GUIDData, GUID},
-    locator::{Locator, LocatorData},
+    locator::{Data as LocatorData, Locator},
     parameter_id::ParameterId,
   },
 };
@@ -653,7 +653,7 @@ impl<'a> BuiltinDataSerializer<'a> {
     for locator in locators {
       s.serialize_field(
         "metatraffic_unicast_locators",
-        &LocatorData::from(locator, ParameterId::PID_METATRAFFIC_UNICAST_LOCATOR),
+        &LocatorData::from(*locator, ParameterId::PID_METATRAFFIC_UNICAST_LOCATOR),
       )
       .unwrap();
     }
@@ -669,7 +669,7 @@ impl<'a> BuiltinDataSerializer<'a> {
     for locator in locators {
       s.serialize_field(
         "metatraffic_multicast_locators",
-        &LocatorData::from(locator, ParameterId::PID_METATRAFFIC_MULTICAST_LOCATOR),
+        &LocatorData::from(*locator, ParameterId::PID_METATRAFFIC_MULTICAST_LOCATOR),
       )
       .unwrap();
     }
@@ -685,7 +685,7 @@ impl<'a> BuiltinDataSerializer<'a> {
     for locator in locators {
       s.serialize_field(
         "default_unicast_locators",
-        &LocatorData::from(locator, ParameterId::PID_DEFAULT_UNICAST_LOCATOR),
+        &LocatorData::from(*locator, ParameterId::PID_DEFAULT_UNICAST_LOCATOR),
       )
       .unwrap();
     }
@@ -701,7 +701,7 @@ impl<'a> BuiltinDataSerializer<'a> {
     for locator in locators {
       s.serialize_field(
         "default_multicast_locators",
-        &LocatorData::from(locator, ParameterId::PID_DEFAULT_MULTICAST_LOCATOR),
+        &LocatorData::from(*locator, ParameterId::PID_DEFAULT_MULTICAST_LOCATOR),
       )
       .unwrap();
     }
@@ -774,7 +774,7 @@ impl<'a> BuiltinDataSerializer<'a> {
     for locator in locators {
       s.serialize_field(
         "default_unicast_locators",
-        &LocatorData::from(locator, ParameterId::PID_UNICAST_LOCATOR),
+        &LocatorData::from(*locator, ParameterId::PID_UNICAST_LOCATOR),
       )
       .unwrap();
     }
@@ -790,7 +790,7 @@ impl<'a> BuiltinDataSerializer<'a> {
     for locator in locators {
       s.serialize_field(
         "default_unicast_locators",
-        &LocatorData::from(locator, ParameterId::PID_MULTICAST_LOCATOR),
+        &LocatorData::from(*locator, ParameterId::PID_MULTICAST_LOCATOR),
       )
       .unwrap();
     }


### PR DESCRIPTION
refactor `Locator` to use an idiomatic type.

This is a draft as the serialization strategy used in this library is tightly-coupled to the internal representation of the types. Makes it tricky to change the layout of any types