### PR TITLE
remove 'LocatorList'

### DIFF
--- a/src/dds/message_receiver.rs
+++ b/src/dds/message_receiver.rs
@@ -15,7 +15,7 @@ use crate::{
   structure::{
     entity::RTPSEntity,
     guid::{EntityId, GuidPrefix, GUID},
-    locator::{Locator, LocatorKind, LocatorList},
+    locator::{Locator, LocatorKind},
     time::Timestamp,
   },
 };
@@ -46,8 +46,8 @@ pub(crate) struct MessageReceiver {
   pub source_vendor_id: VendorId,
   pub source_guid_prefix: GuidPrefix,
   pub dest_guid_prefix: GuidPrefix,
-  pub unicast_reply_locator_list: LocatorList,
-  pub multicast_reply_locator_list: LocatorList,
+  pub unicast_reply_locator_list: Vec<Locator>,
+  pub multicast_reply_locator_list: Vec<Locator>,
   pub timestamp: Option<Timestamp>,
 
   pos: usize,
@@ -393,8 +393,8 @@ impl MessageReceiver {
 pub struct MessageReceiverState {
   //pub own_guid_prefix: GuidPrefix,
   pub source_guid_prefix: GuidPrefix,
-  pub unicast_reply_locator_list: LocatorList,
-  pub multicast_reply_locator_list: LocatorList,
+  pub unicast_reply_locator_list: Vec<Locator>,
+  pub multicast_reply_locator_list: Vec<Locator>,
   pub timestamp: Option<Timestamp>,
 }
 
@@ -403,8 +403,8 @@ impl Default for MessageReceiverState {
     Self {
       //own_guid_prefix: GuidPrefix::default(),
       source_guid_prefix: GuidPrefix::default(),
-      unicast_reply_locator_list: LocatorList::default(),
-      multicast_reply_locator_list: LocatorList::default(),
+      unicast_reply_locator_list: Vec::default(),
+      multicast_reply_locator_list: Vec::default(),
       timestamp: Some(Timestamp::TIME_INVALID),
     }
   }

--- a/src/dds/reader.rs
+++ b/src/dds/reader.rs
@@ -42,8 +42,6 @@ use crate::{
     time::Timestamp,
   },
 };
-#[cfg(test)]
-use crate::structure::locator::LocatorList;
 use super::{qos::InlineQos, with_key::datareader::ReaderCommand};
 
 #[derive(Clone, Copy, Debug, PartialEq, Eq)]
@@ -403,8 +401,8 @@ impl Reader {
     &mut self,
     remote_writer_guid: GUID,
     remote_group_entity_id: EntityId,
-    unicast_locator_list: LocatorList,
-    multicast_locator_list: LocatorList,
+    unicast_locator_list: Vec<Locator>,
+    multicast_locator_list: Vec<Locator>,
   ) {
     let proxy = RtpsWriterProxy::new(
       remote_writer_guid,

--- a/src/dds/rtps_reader_proxy.rs
+++ b/src/dds/rtps_reader_proxy.rs
@@ -16,7 +16,7 @@ use crate::{
   },
   structure::{
     guid::{EntityId, EntityKind, GUID},
-    locator::{Locator, LocatorList},
+    locator::Locator,
     sequence_number::SequenceNumber,
   },
 };
@@ -33,11 +33,11 @@ pub(crate) struct RtpsReaderProxy {
   pub remote_group_entity_id: EntityId,
   /// List of unicast locators (transport, address, port combinations) that can
   /// be used to send messages to the matched RTPS Reader. The list may be empty
-  pub unicast_locator_list: LocatorList,
+  pub unicast_locator_list: Vec<Locator>,
   /// List of multicast locators (transport, address, port combinations) that
   /// can be used to send messages to the matched RTPS Reader. The list may be
   /// empty
-  pub multicast_locator_list: LocatorList,
+  pub multicast_locator_list: Vec<Locator>,
 
   /// Specifies whether the remote matched RTPS Reader expects in-line QoS to be
   /// sent along with any data.
@@ -63,8 +63,8 @@ impl RtpsReaderProxy {
     RtpsReaderProxy {
       remote_reader_guid,
       remote_group_entity_id: EntityId::ENTITYID_UNKNOWN,
-      unicast_locator_list: LocatorList::new(),
-      multicast_locator_list: LocatorList::new(),
+      unicast_locator_list: Vec::default(),
+      multicast_locator_list: Vec::default(),
       expects_in_line_qos: false,
       is_active: true,
       all_acked_before: SequenceNumber::zero(),
@@ -113,8 +113,8 @@ impl RtpsReaderProxy {
 
   pub fn from_discovered_reader_data(
     discovered_reader_data: &DiscoveredReaderData,
-    default_unicast_locators: LocatorList,
-    default_multicast_locators: LocatorList,
+    default_unicast_locators: Vec<Locator>,
+    default_multicast_locators: Vec<Locator>,
   ) -> RtpsReaderProxy {
     let unicast_locator_list = Self::discovered_or_default(
       &discovered_reader_data.reader_proxy.unicast_locator_list,
@@ -150,7 +150,7 @@ impl RtpsReaderProxy {
   }
 
   pub fn new_for_unit_testing(port_number: u16) -> RtpsReaderProxy {
-    let mut unicast_locators = LocatorList::new();
+    let mut unicast_locators = Vec::default();
     let locator = Locator::from(SocketAddr::new(
       std::net::IpAddr::V4(Ipv4Addr::new(127, 0, 0, 1)),
       port_number,
@@ -160,7 +160,7 @@ impl RtpsReaderProxy {
       remote_reader_guid: GUID::dummy_test_guid(EntityKind::READER_WITH_KEY_USER_DEFINED),
       remote_group_entity_id: EntityId::ENTITYID_UNKNOWN,
       unicast_locator_list: unicast_locators,
-      multicast_locator_list: LocatorList::new(),
+      multicast_locator_list: Vec::default(),
       expects_in_line_qos: false,
 
       is_active: true,

--- a/src/dds/rtps_writer_proxy.rs
+++ b/src/dds/rtps_writer_proxy.rs
@@ -11,7 +11,7 @@ use crate::{
   messages::submessages::submessages::{DATAFRAG_Flags, DataFrag},
   structure::{
     guid::{EntityId, GUID},
-    locator::LocatorList,
+    locator::Locator,
     sequence_number::SequenceNumber,
     time::Timestamp,
   },
@@ -24,11 +24,11 @@ pub(crate) struct RtpsWriterProxy {
 
   /// List of unicast (address, port) combinations that can be used to send
   /// messages to the matched Writer or Writers. The list may be empty.
-  pub unicast_locator_list: LocatorList,
+  pub unicast_locator_list: Vec<Locator>,
 
   /// List of multicast (address, port) combinations that can be used to send
   /// messages to the matched Writer or Writers. The list may be empty.
-  pub multicast_locator_list: LocatorList,
+  pub multicast_locator_list: Vec<Locator>,
 
   /// Identifies the group to which the matched Reader belongs
   pub remote_group_entity_id: EntityId,
@@ -52,8 +52,8 @@ pub(crate) struct RtpsWriterProxy {
 impl RtpsWriterProxy {
   pub fn new(
     remote_writer_guid: GUID,
-    unicast_locator_list: LocatorList,
-    multicast_locator_list: LocatorList,
+    unicast_locator_list: Vec<Locator>,
+    multicast_locator_list: Vec<Locator>,
     remote_group_entity_id: EntityId,
   ) -> Self {
     Self {

--- a/src/discovery/data_types/spdp_participant_data.rs
+++ b/src/discovery/data_types/spdp_participant_data.rs
@@ -24,7 +24,7 @@ use crate::{
     duration::Duration,
     entity::RTPSEntity,
     guid::{EntityId, GUID},
-    locator::LocatorList,
+    locator::Locator,
   },
 };
 
@@ -41,10 +41,10 @@ pub struct SpdpDiscoveredParticipantData {
   pub vendor_id: VendorId,
   pub expects_inline_qos: bool,
   pub participant_guid: GUID,
-  pub metatraffic_unicast_locators: LocatorList,
-  pub metatraffic_multicast_locators: LocatorList,
-  pub default_unicast_locators: LocatorList,
-  pub default_multicast_locators: LocatorList,
+  pub metatraffic_unicast_locators: Vec<Locator>,
+  pub metatraffic_multicast_locators: Vec<Locator>,
+  pub default_unicast_locators: Vec<Locator>,
+  pub default_multicast_locators: Vec<Locator>,
   pub available_builtin_endpoints: BuiltinEndpointSet,
   pub lease_duration: Option<Duration>,
   pub manual_liveliness_count: i32,

--- a/src/discovery/data_types/topic_data.rs
+++ b/src/discovery/data_types/topic_data.rs
@@ -34,7 +34,7 @@ use crate::{
   structure::{
     entity::RTPSEntity,
     guid::{EntityKind, GuidPrefix, GUID},
-    locator::LocatorList,
+    locator::Locator,
   },
 };
 
@@ -47,8 +47,8 @@ use crate::{
 pub struct ReaderProxy {
   pub remote_reader_guid: GUID,
   pub expects_inline_qos: bool,
-  pub unicast_locator_list: LocatorList,
-  pub multicast_locator_list: LocatorList,
+  pub unicast_locator_list: Vec<Locator>,
+  pub multicast_locator_list: Vec<Locator>,
 }
 
 impl ReaderProxy {
@@ -420,16 +420,16 @@ impl Serialize for DiscoveredReaderDataKey {
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
 pub struct WriterProxy {
   pub remote_writer_guid: GUID,
-  pub unicast_locator_list: LocatorList,
-  pub multicast_locator_list: LocatorList,
+  pub unicast_locator_list: Vec<Locator>,
+  pub multicast_locator_list: Vec<Locator>,
   pub data_max_size_serialized: Option<u32>,
 }
 
 impl WriterProxy {
   pub fn new(
     guid: GUID,
-    multicast_locator_list: LocatorList,
-    unicast_locator_list: LocatorList,
+    multicast_locator_list: Vec<Locator>,
+    unicast_locator_list: Vec<Locator>,
   ) -> WriterProxy {
     WriterProxy {
       remote_writer_guid: guid,

--- a/src/discovery/discovery_db.rs
+++ b/src/discovery/discovery_db.rs
@@ -15,7 +15,7 @@ use crate::{
     duration::Duration,
     entity::RTPSEntity,
     guid::{EntityId, GuidPrefix, GUID},
-    locator::LocatorList,
+    locator::Locator,
   },
 };
 use super::data_types::{
@@ -323,7 +323,7 @@ impl DiscoveryDB {
                 self.participant_proxies.keys()
               );
             }
-            (LocatorList::new(), LocatorList::new())
+            (Vec::default(), Vec::default())
           });
         debug!("External reader: {:?}", data);
         Some((

--- a/src/discovery/participant_proxy.rs
+++ b/src/discovery/participant_proxy.rs
@@ -1,7 +1,7 @@
 /*
 use serde::{Serialize, Deserialize};
 
-use crate::structure::{guid::*, locator::LocatorList};
+use crate::structure::{guid::*, locator::Locator};
 
 use crate::messages::{protocol_version::ProtocolVersion, vendor_id::VendorId};
 
@@ -33,12 +33,12 @@ pub struct ParticipantProxyAttributes {
   /// List of unicast locators (transport, address, port
   /// combinations) that can be used to send messages to
   /// the built-in Endpoints contained in the Participant.
-  pub metatraffic_unicast_locator_list: LocatorList,
+  pub metatraffic_unicast_locator_list: Vec<Locator>,
 
   /// List of multicast locators (transport, address, port
   /// combinations) that can be used to send messages to
   /// the built-in Endpoints contained in the Participant.
-  pub metatraffic_multicast_locator_list: LocatorList,
+  pub metatraffic_multicast_locator_list: Vec<Locator>,
 
   /// Default list of unicast locators (transport, address, port
   /// combinations) that can be used to send messages to
@@ -47,14 +47,14 @@ pub struct ParticipantProxyAttributes {
   /// These are the unicast locators that will be used in case
   /// the Endpoint does not specify its own set of Locators, so
   /// at least one Locator must be present
-  pub default_unicast_locator_list: LocatorList,
+  pub default_unicast_locator_list: Vec<Locator>,
 
   /// Default list of multicast locators (transport, address,
   /// port combinations) that can be used to send messages to
   /// the user-defined Endpoints contained in the Participant.
   /// These are the multicast locators that will be used in case
   /// the Endpoint does not specify its own set of Locators.
-  pub default_multicast_locator_list: LocatorList,
+  pub default_multicast_locator_list: Vec<Locator>,
 
   /// All Participants must support the SEDP. This attribute
   /// identifies the kinds of built-in SEDP Endpoints that are

--- a/src/messages/submessages/info_reply.rs
+++ b/src/messages/submessages/info_reply.rs
@@ -1,6 +1,6 @@
 use speedy::{Readable, Writable};
 
-use crate::structure::locator::LocatorList;
+use crate::structure::locator::Locator;
 
 /// This message is sent from an RTPS Reader to an RTPS Writer.
 /// It contains explicit information on where to send a reply
@@ -10,12 +10,12 @@ pub struct InfoReply {
   /// Indicates an alternative set of unicast addresses that
   /// the Writershould use to reach the Readers when
   /// replying to the Submessages that follow.
-  pub unicast_locator_list: LocatorList,
+  pub unicast_locator_list: Vec<Locator>,
 
   /// Indicates an alternative set of multicast addresses that the Writer
   /// should use to reach the Readers when replying to the Submessages that
   /// follow.
   ///
   /// Only present when the MulticastFlag is set.
-  pub multicast_locator_list: Option<LocatorList>,
+  pub multicast_locator_list: Option<Vec<Locator>>,
 }

--- a/src/network/util.rs
+++ b/src/network/util.rs
@@ -6,9 +6,9 @@ use std::{
 #[allow(unused_imports)]
 use log::{debug, error, info, trace};
 
-use crate::structure::locator::{Locator, LocatorList};
+use crate::structure::locator::Locator;
 
-pub fn get_local_multicast_locators(port: u16) -> LocatorList {
+pub fn get_local_multicast_locators(port: u16) -> Vec<Locator> {
   let saddr = SocketAddr::new("239.255.0.1".parse().unwrap(), port);
   vec![Locator::from(saddr)]
 }
@@ -24,7 +24,7 @@ pub fn get_local_multicast_ip_addrs() -> io::Result<Vec<IpAddr>> {
   )
 }
 
-pub fn get_local_unicast_socket_address(port: u16) -> LocatorList {
+pub fn get_local_unicast_socket_address(port: u16) -> Vec<Locator> {
   match if_addrs::get_if_addrs() {
     Ok(ifaces) => ifaces
       .iter()

--- a/src/serialization/builtin_data_deserializer.rs
+++ b/src/serialization/builtin_data_deserializer.rs
@@ -38,7 +38,7 @@ use crate::{
     duration::Duration,
     endpoint::ReliabilityKind,
     guid::GUID,
-    locator::{Locator, LocatorList},
+    locator::Locator,
     parameter_id::ParameterId,
   },
 };
@@ -51,10 +51,10 @@ pub struct BuiltinDataDeserializer {
   pub vendor_id: Option<VendorId>,
   pub expects_inline_qos: Option<bool>,
   pub participant_guid: Option<GUID>,
-  pub metatraffic_unicast_locators: LocatorList,
-  pub metatraffic_multicast_locators: LocatorList,
-  pub default_unicast_locators: LocatorList,
-  pub default_multicast_locators: LocatorList,
+  pub metatraffic_unicast_locators: Vec<Locator>,
+  pub metatraffic_multicast_locators: Vec<Locator>,
+  pub default_unicast_locators: Vec<Locator>,
+  pub default_multicast_locators: Vec<Locator>,
   pub available_builtin_endpoints: Option<BuiltinEndpointSet>,
   pub lease_duration: Option<Duration>,
   pub manual_liveliness_count: Option<i32>,
@@ -65,8 +65,8 @@ pub struct BuiltinDataDeserializer {
   pub endpoint_guid: Option<GUID>,
 
   // Reader Proxy
-  pub unicast_locator_list: LocatorList,
-  pub multicast_locator_list: LocatorList,
+  pub unicast_locator_list: Vec<Locator>,
+  pub multicast_locator_list: Vec<Locator>,
 
   // Writer Proxy
   pub data_max_size_serialized: Option<u32>,

--- a/src/serialization/builtin_data_serializer.rs
+++ b/src/serialization/builtin_data_serializer.rs
@@ -32,7 +32,7 @@ use crate::{
     duration::{Duration, DurationData},
     endpoint::ReliabilityKind,
     guid::{GUIDData, GUID},
-    locator::{LocatorData, LocatorList},
+    locator::{Locator, LocatorData},
     parameter_id::ParameterId,
   },
 };
@@ -156,10 +156,10 @@ pub struct BuiltinDataSerializer<'a> {
   pub vendor_id: Option<VendorId>,
   pub expects_inline_qos: Option<bool>,
   pub participant_guid: Option<GUID>,
-  pub metatraffic_unicast_locators: Option<&'a LocatorList>,
-  pub metatraffic_multicast_locators: Option<&'a LocatorList>,
-  pub default_unicast_locators: Option<&'a LocatorList>,
-  pub default_multicast_locators: Option<&'a LocatorList>,
+  pub metatraffic_unicast_locators: Option<&'a Vec<Locator>>,
+  pub metatraffic_multicast_locators: Option<&'a Vec<Locator>>,
+  pub default_unicast_locators: Option<&'a Vec<Locator>>,
+  pub default_multicast_locators: Option<&'a Vec<Locator>>,
   pub available_builtin_endpoints: Option<BuiltinEndpointSet>,
   pub lease_duration: Option<Duration>,
   pub manual_liveliness_count: Option<i32>,
@@ -169,8 +169,8 @@ pub struct BuiltinDataSerializer<'a> {
   pub endpoint_guid: Option<GUID>,
 
   // Reader Proxy
-  pub unicast_locator_list: Option<&'a LocatorList>,
-  pub multicast_locator_list: Option<&'a LocatorList>,
+  pub unicast_locator_list: Option<&'a Vec<Locator>>,
+  pub multicast_locator_list: Option<&'a Vec<Locator>>,
 
   // Writer Proxy
   pub data_max_size_serialized: Option<u32>,
@@ -551,7 +551,7 @@ impl<'a> BuiltinDataSerializer<'a> {
   fn fields_amount(&self) -> usize {
     let mut count: usize = 0;
 
-    let empty_ll = LocatorList::new();
+    let empty_ll = Vec::default();
     count += self.protocol_version.is_some() as usize;
     count += self.vendor_id.is_some() as usize;
     count += self.expects_inline_qos.is_some() as usize;

--- a/src/structure/endpoint.rs
+++ b/src/structure/endpoint.rs
@@ -1,7 +1,7 @@
 use speedy::{Readable, Writable};
 use serde::{Deserialize, Serialize};
 
-use crate::structure::{locator::LocatorList, topic_kind};
+use crate::structure::{locator::Locator, topic_kind};
 
 #[derive(Debug, Clone, PartialEq, Eq, Readable, Writable, Serialize, Deserialize)]
 pub struct ReliabilityKind(u32);
@@ -25,11 +25,11 @@ pub struct EndpointAttributes {
 
   /// List of unicast locators (transport, address, port combinations) that
   /// can be used to send messages to the Endpoint. The list may be empty.
-  pub unicast_locator_list: LocatorList,
+  pub unicast_locator_list: Vec<Locator>,
 
   /// List of multicast locators (transport, address, port combinations) that
   /// can be used to send messages to the Endpoint. The list may be empty.
-  pub multicast_locator_list: LocatorList,
+  pub multicast_locator_list: Vec<Locator>,
 }
 
 impl EndpointAttributes {
@@ -37,8 +37,8 @@ impl EndpointAttributes {
     EndpointAttributes {
       topic_kind: topic_kind::TopicKind::NoKey,
       reliability_level: ReliabilityKind::BEST_EFFORT,
-      unicast_locator_list: LocatorList::new(),
-      multicast_locator_list: LocatorList::new(),
+      unicast_locator_list: Vec::default(),
+      multicast_locator_list: Vec::default(),
     }
   }
 }

--- a/src/structure/locator.rs
+++ b/src/structure/locator.rs
@@ -38,8 +38,6 @@ pub struct Locator {
   pub address: [u8; 16],
 }
 
-pub type LocatorList = Vec<Locator>;
-
 impl Locator {
   pub const LOCATOR_INVALID: Locator = Locator {
     kind: LocatorKind::LOCATOR_KIND_INVALID,


### PR DESCRIPTION
removed the `LocatorList = Vec<Locator>` type alias

this adds unnecessary indirection. the term `LocatorList` is used in the spec to avoid using a concrete type, but this isn't necessary in code, since it's clear in context that a `Vec<Locator>` is a list of locators.