### PR TITLE
add coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,0 +1,29 @@
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+name: Code Coverage
+
+jobs:
+  coverage:
+    name: coverage
+    runs-on: ubuntu-latest
+    steps:
+      - name: checkout source
+        uses: actions/checkout@v2
+
+      - name: Install nightly toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: nightly
+          profile: minimal
+          override: true
+
+      - name: Run cargo-tarpaulin
+        uses: actions-rs/tarpaulin@v0.1
+        with:
+          args: --tests --doc
+
+      - name: Upload to codecov.io
+        uses: codecov/codecov-action@v2.1.0

--- a/src/dds/no_key/datawriter.rs
+++ b/src/dds/no_key/datawriter.rs
@@ -340,7 +340,7 @@ where
   ///
   /// # Examples
   // TODO: enable run when implemented
-  /// ```no_run
+  /// ```no_run ignore
   /// # use serde::{Serialize, Deserialize};
   /// # use rustdds::dds::DomainParticipant;
   /// # use rustdds::dds::qos::QosPolicyBuilder;


### PR DESCRIPTION
adds a test coverage workflow.

to see the benefit from this, you'd need to register an account with codecov.io (you can use github credentials)