### PR TITLE
Fix branch name in coverage workflow

### DIFF
--- a/.github/workflows/coverage.yml
+++ b/.github/workflows/coverage.yml
@@ -1,6 +1,6 @@
 on:
   push:
-    branches: [main]
+    branches: [master]
   pull_request:
 
 name: Code Coverage


### PR DESCRIPTION
My bad. The branch name should be 'master' not 'main'.

Copy-paste error on my part