### PR TITLE
Support interrupt while waitting for timeout in find topic

### DIFF
--- a/src/dds/dp_event_loop.rs
+++ b/src/dds/dp_event_loop.rs
@@ -774,7 +774,10 @@ mod tests {
       mio_channel::channel();
 
     let ddshc = Arc::new(RwLock::new(DDSCache::new()));
-    let discovery_db = Arc::new(RwLock::new(DiscoveryDB::new(GUID::new_particiapnt_guid())));
+    let discovery_db = Arc::new(RwLock::new(DiscoveryDB::new(
+      GUID::new_particiapnt_guid(),
+      None,
+    )));
 
     let domain_info = DomainInfo {
       domain_participant_guid: GUID::default(),

--- a/src/dds/participant.rs
+++ b/src/dds/participant.rs
@@ -813,9 +813,8 @@ impl DomainParticipantInner {
       let type_desc = d.topic_data.type_name.clone();
       self.create_topic(domain_participant_weak, name, type_desc, &qos, topic_kind)
     };
-    let maybe_discovered_topic = db.get_all_topics().find(|&d| d.get_topic_name() == name);
 
-    if let Some(d) = maybe_discovered_topic {
+    if let Some(d) = db.get_topic(name) {
       // build a Topic from DiscoveredTopicData
       return build_topic_fn(d).map(Some);
     }

--- a/src/discovery/discovery_db.rs
+++ b/src/discovery/discovery_db.rs
@@ -1,6 +1,7 @@
 use std::{
   collections::{BTreeMap, HashMap},
   time::Instant,
+  sync::{Arc, Condvar, Mutex},
 };
 
 #[allow(unused_imports)]
@@ -15,7 +16,6 @@ use crate::{
     duration::Duration,
     entity::RTPSEntity,
     guid::{EntityId, GuidPrefix, GUID},
-    locator::Locator,
   },
 };
 use super::data_types::{
@@ -47,6 +47,7 @@ pub(crate) struct DiscoveryDB {
   external_topic_writers: BTreeMap<GUID, DiscoveredWriterData>,
 
   topics: HashMap<String, DiscoveredTopicData>,
+  lastest_topic: Arc<(Mutex<Option<DiscoveredTopicData>>, Condvar)>,
 
   readers_updated: bool,
   writers_updated: bool,
@@ -63,6 +64,7 @@ impl DiscoveryDB {
       external_topic_readers: BTreeMap::new(),
       external_topic_writers: BTreeMap::new(),
       topics: HashMap::new(),
+      lastest_topic: Arc::new((Mutex::new(None), Condvar::new())),
       readers_updated: false,
       writers_updated: false,
     }
@@ -428,6 +430,11 @@ impl DiscoveryDB {
     match self.topics.get_mut(&data.topic_data.name) {
       Some(t) => *t = data.clone(),
       None => {
+        let (lock, cvar) = &*self.lastest_topic;
+        let mut lastest_topic = lock.lock().unwrap();
+        *lastest_topic = Some(data.clone());
+        cvar.notify_all();
+
         self.topics.insert(topic_name, data.clone());
       }
     };
@@ -509,6 +516,27 @@ impl DiscoveryDB {
       .iter()
       .filter(|(s, _)| !s.starts_with("DCPS"))
       .map(|(_, v)| v)
+  }
+
+  pub fn wait_new_topic_fn(
+    &self,
+    topic_name: impl Into<String>,
+    timeout: std::time::Duration,
+  ) -> impl Fn() -> Option<DiscoveredTopicData> {
+    let lastest_topic = self.lastest_topic.clone();
+    let topic_name: String = topic_name.into();
+    move || {
+      let (lock, cvar) = &*lastest_topic;
+      let result = cvar
+        .wait_timeout_while(lock.lock().unwrap(), timeout, |lastest_topic_data| {
+          lastest_topic_data.as_ref().map(|e| &e.topic_data.name) == Some(&topic_name)
+        })
+        .unwrap();
+      if result.1.timed_out() {
+        return None;
+      }
+      result.0.clone()
+    }
   }
 
   // // TODO: return iterator somehow?

--- a/src/messages/submessages/gap.rs
+++ b/src/messages/submessages/gap.rs
@@ -10,9 +10,7 @@ use crate::{
     sequence_number::{SequenceNumber, SequenceNumberSet},
   },
 };
-use super::{
-  submessage::EntitySubmessage, submessage_flag::GAP_Flags, submessage_kind::SubmessageKind,
-};
+use super::{submessage::EntitySubmessage, submessage_flag::GAP_Flags, submessage_kind::SubmessageKind};
 /// This Submessage is sent from an RTPS Writer to an RTPS Reader and
 /// indicates to the RTPS Reader that a range of sequence numbers
 /// is no longer relevant. The set may be a contiguous range of

--- a/src/messages/submessages/gap.rs
+++ b/src/messages/submessages/gap.rs
@@ -10,7 +10,9 @@ use crate::{
     sequence_number::{SequenceNumber, SequenceNumberSet},
   },
 };
-use super::{submessage::EntitySubmessage, submessage_flag::GAP_Flags, submessage_kind::SubmessageKind};
+use super::{
+  submessage::EntitySubmessage, submessage_flag::GAP_Flags, submessage_kind::SubmessageKind,
+};
 /// This Submessage is sent from an RTPS Writer to an RTPS Reader and
 /// indicates to the RTPS Reader that a range of sequence numbers
 /// is no longer relevant. The set may be a contiguous range of


### PR DESCRIPTION
Since the ENTIRE DiscoveryDB is protected by a single lock, we cannot wait on it member value or partially access it member value without locking the entitre object.
To provide interrupt feature in such situation while minimize the performance loss, it need to store a extra copy of some variable and implemented in a indirect way.
This may not be a straightforward solution, but a workable solution without massive code change.

It may be better to let DiscoveryDB itself provide a internal thread safe protection. Then, it can be done in a more efficient way.
I may work on it in future.