### PR TITLE
remove prefix from getters

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ The payload type D is required to implement `serde::Serialize` when used with a 
 
 In DDS, a WITH_KEY topic contains multiple different instances, that are distinguished by a key. The key must be somehow embedded into the data samples. In our implementation, if the payload type D is communicated in a WITH_KEY topic, then D is additionally required to implement trait `Keyed`.
 
-The trait `Keyed` requires one method: `get_key(&self) -> Self::K` , which is used to extract a key of an associated type `K` from `D`. They key type `K` must implement trait `Key`, which is a combination of pre-existing traits `Eq + 
+The trait `Keyed` requires one method: `key(&self) -> Self::K` , which is used to extract a key of an associated type `K` from `D`. They key type `K` must implement trait `Key`, which is a combination of pre-existing traits `Eq + 
 PartialEq + PartialOrd + Ord + Hash + Clone + Serialize + DeserializeOwned` and no additional methods.
 
 A serializer adapter type SA (wrapper for a Serde data format) is provided for OMG Common Data Representation (CDR), as this is the default serialization format used by DDS/RTPS. It is possible to use another serialization format for the objects communicated over DDS by providing a Serde [data format][serde-data-format-url] implementation.

--- a/examples/ros2_demo/main.rs
+++ b/examples/ros2_demo/main.rs
@@ -164,7 +164,7 @@ fn ros2_loop(command_receiver: mio_channel::Receiver<RosCommand>) {
             None => (),
           }
         } else if event.token() == TOPIC_UPDATE_TIMER_TOKEN {
-          let list = ros_participant.get_discovered_topics();
+          let list = ros_participant.discovered_topics();
           match &nodes_updated_sender {
             Some(s) => s.send(DataUpdate::TopicList { list }).unwrap(),
             None => (),

--- a/examples/ros2_demo/ros2/turtle_data.rs
+++ b/examples/ros2_demo/ros2/turtle_data.rs
@@ -50,7 +50,7 @@ impl TurtleCmdVelTopic {
     String::from("geometry_msgs::msg::dds_::Twist_")
   }
 
-  pub fn get_qos() -> QosPolicies {
+  pub fn qos() -> QosPolicies {
     QOS.clone()
   }
 }

--- a/examples/ros2_demo/structures.rs
+++ b/examples/ros2_demo/structures.rs
@@ -210,8 +210,8 @@ impl<'a> MainController<'a> {
               self.stdout,
               "{}{}{}",
               termion::cursor::Goto(1, 21 + i as u16),
-              node_info.get_namespace(),
-              node_info.get_name()
+              node_info.namespace(),
+              node_info.name()
             )
             .unwrap();
           }
@@ -221,15 +221,15 @@ impl<'a> MainController<'a> {
           let (topics, services): (Vec<&DiscoveredTopicData>, Vec<&DiscoveredTopicData>) =
             topic_list
               .iter()
-              .partition(|p| p.get_topic_name().starts_with("rt"));
+              .partition(|p| p.topic_name().starts_with("rt"));
           let (services_request, services): (Vec<&DiscoveredTopicData>, Vec<&DiscoveredTopicData>) =
             services
               .iter()
-              .partition(|p| p.get_topic_name().starts_with("rq"));
+              .partition(|p| p.topic_name().starts_with("rq"));
           let (services_reply, dds_topics): (Vec<&DiscoveredTopicData>, Vec<&DiscoveredTopicData>) =
             services
               .iter()
-              .partition(|p| p.get_topic_name().starts_with("rr"));
+              .partition(|p| p.topic_name().starts_with("rr"));
 
           write!(
             self.stdout,
@@ -241,11 +241,7 @@ impl<'a> MainController<'a> {
 
           let mut max_width = 9;
           for (i, topic_info) in topics.iter().enumerate() {
-            let ft = format!(
-              "{} - {}",
-              topic_info.get_topic_name(),
-              topic_info.get_type_name()
-            );
+            let ft = format!("{} - {}", topic_info.topic_name(), topic_info.type_name());
             max_width = if ft.len() > max_width {
               ft.len()
             } else {
@@ -270,8 +266,8 @@ impl<'a> MainController<'a> {
           for (i, service_info) in services_request.iter().enumerate() {
             let ft = format!(
               "{} - {}",
-              service_info.get_topic_name(),
-              service_info.get_type_name()
+              service_info.topic_name(),
+              service_info.type_name()
             );
             write!(
               self.stdout,
@@ -299,11 +295,7 @@ impl<'a> MainController<'a> {
 
           max_width = 20;
           for (i, reply_info) in services_reply.iter().enumerate() {
-            let ft = format!(
-              "{} - {}",
-              reply_info.get_topic_name(),
-              reply_info.get_type_name()
-            );
+            let ft = format!("{} - {}", reply_info.topic_name(), reply_info.type_name());
             max_width = if ft.len() > max_width {
               ft.len()
             } else {
@@ -327,11 +319,7 @@ impl<'a> MainController<'a> {
           .unwrap();
 
           for (i, dds_info) in dds_topics.iter().enumerate() {
-            let ft = format!(
-              "{} - {}",
-              dds_info.get_topic_name(),
-              dds_info.get_type_name()
-            );
+            let ft = format!("{} - {}", dds_info.topic_name(), dds_info.type_name());
             write!(
               self.stdout,
               "{}{}",

--- a/examples/ros2_demo/turtle_listener.rs
+++ b/examples/ros2_demo/turtle_listener.rs
@@ -35,7 +35,7 @@ impl TurtleListener {
       .create_ros_topic(
         &TurtleCmdVelTopic::topic_name(),
         TurtleCmdVelTopic::type_name(),
-        TurtleCmdVelTopic::get_qos(),
+        TurtleCmdVelTopic::qos(),
         TurtleCmdVelTopic::topic_kind(),
       )
       .unwrap();

--- a/examples/ros2_demo/turtle_sender.rs
+++ b/examples/ros2_demo/turtle_sender.rs
@@ -34,7 +34,7 @@ impl TurtleSender {
       .create_ros_topic(
         &TurtleCmdVelTopic::topic_name(),
         TurtleCmdVelTopic::type_name(),
-        TurtleCmdVelTopic::get_qos(),
+        TurtleCmdVelTopic::qos(),
         TurtleCmdVelTopic::topic_kind(),
       )
       .unwrap();

--- a/examples/shapes_demo/main.rs
+++ b/examples/shapes_demo/main.rs
@@ -40,7 +40,7 @@ struct Shape {
 
 impl Keyed for Shape {
   type K = String;
-  fn get_key(&self) -> String {
+  fn key(&self) -> String {
     self.color.clone()
   }
 }
@@ -138,7 +138,7 @@ fn main() {
     .unwrap_or_else(|e| panic!("create_topic failed: {:?}", e));
   println!(
     "Topic name is {}. Type is {}.",
-    topic.get_name(),
+    topic.name(),
     topic.get_type().name()
   );
 
@@ -248,7 +248,7 @@ fn main() {
                   Ok(Some(sample)) => match sample.into_value() {
                     Ok(sample) => println!(
                       "{:10.10} {:10.10} {:3.3} {:3.3} [{}]",
-                      topic.get_name(),
+                      topic.name(),
                       sample.color,
                       sample.x,
                       sample.y,

--- a/src/dds/datasample_cache.rs
+++ b/src/dds/datasample_cache.rs
@@ -70,9 +70,9 @@ where
   D: Keyed,
   <D as Keyed>::K: Key,
 {
-  pub fn get_key(&self) -> D::K {
+  pub fn key(&self) -> D::K {
     match &self.sample {
-      Ok(d) => d.get_key(),
+      Ok(d) => d.key(),
       Err(k) => k.clone(),
     }
   }
@@ -100,7 +100,7 @@ where
     source_timestamp: Option<Timestamp>,
   ) {
     let instance_key = match &new_sample {
-      Ok(d) => d.get_key(),
+      Ok(d) => d.key(),
       Err(k) => k.clone(),
     };
 
@@ -230,7 +230,7 @@ where
       .datasamples
       .iter()
       .filter_map(|(ts, dsm)| {
-        let key = dsm.get_key();
+        let key = dsm.key();
         if self.sample_selector(&rc, self.instance_map.get(&key).unwrap(), dsm) {
           Some((*ts, key))
         } else {
@@ -534,12 +534,12 @@ where
   }
   */
 
-  pub fn get_key_by_hash(&self, key_hash: KeyHash) -> Option<D::K> {
+  pub fn key_by_hash(&self, key_hash: KeyHash) -> Option<D::K> {
     match self.hash_to_key_map.get(&key_hash) {
       Some(k) => Some(k.clone()),
       None => {
         debug!(
-          "get_key_by_hash: requested KeyHash {:?}, but not found. I have {:?}",
+          "key_by_hash: requested KeyHash {:?}, but not found. I have {:?}",
           key_hash,
           self.hash_to_key_map.keys()
         );
@@ -548,7 +548,7 @@ where
     }
   }
 
-  pub fn get_next_key(&self, key: &D::K) -> Option<D::K> {
+  pub fn next_key(&self, key: &D::K) -> Option<D::K> {
     self
       .instance_map
       .range((Excluded(key), Unbounded))
@@ -585,7 +585,7 @@ mod tests {
 
     let org_ddsdata = DDSData::from(&data, Some(timestamp));
 
-    let key = data.get_key().clone();
+    let key = data.key().clone();
     datasample_cache.add_sample(Ok(data.clone()), GUID::GUID_UNKNOWN, timestamp, None);
     //datasample_cache.add_datasample(datasample).unwrap();
 

--- a/src/dds/dp_event_loop.rs
+++ b/src/dds/dp_event_loop.rs
@@ -244,7 +244,7 @@ impl DPEventLoop {
                       error!("No listener with token {:?}", &event.token());
                       vec![]
                     },
-                    |l| l.get_messages(),
+                    |l| l.messages(),
                   );
                 for packet in udp_messages.into_iter() {
                   ev_wrapper.message_receiver.handle_received_packet(packet)
@@ -322,7 +322,7 @@ impl DPEventLoop {
               if eid.kind().is_reader() {
                 ev_wrapper
                   .message_receiver
-                  .get_reader_mut(eid)
+                  .reader_mut(eid)
                   .map(|reader| reader.process_command())
                   .unwrap_or_else(|| error!("Event for unknown reader {:?}", eid));
               } else if eid.kind().is_writer() {
@@ -334,7 +334,7 @@ impl DPEventLoop {
                   Some(writer) => {
                     // Writer will record data to DDSCache and send it out.
                     writer.process_writer_command();
-                    writer.get_local_readers()
+                    writer.local_readers()
                   }
                 };
                 // Notify local (same participant) readers that new data is available in the
@@ -390,7 +390,7 @@ impl DPEventLoop {
             .poll
             .register(
               &new_reader.data_reader_command_receiver,
-              new_reader.get_entity_token(),
+              new_reader.entity_token(),
               Ready::readable(),
               PollOpt::edge(),
             )
@@ -448,14 +448,12 @@ impl DPEventLoop {
             .poll
             .register(
               &new_writer.writer_command_receiver,
-              new_writer.get_entity_token(),
+              new_writer.entity_token(),
               Ready::readable(),
               PollOpt::edge(),
             )
             .expect("Writer command channel registration failed!!");
-          self
-            .writers
-            .insert(new_writer.get_guid().entity_id, new_writer);
+          self.writers.insert(new_writer.guid().entity_id, new_writer);
         }
       }
       REMOVE_WRITER_TOKEN => {
@@ -487,7 +485,7 @@ impl DPEventLoop {
   }
 
   fn handle_reader_timed_event(&mut self, entity_id: EntityId) {
-    match self.message_receiver.get_reader_mut(entity_id) {
+    match self.message_receiver.reader_mut(entity_id) {
       Some(reader) => reader.handle_timed_event(),
       None => error!("Reader was not found with {:?}", entity_id),
     }
@@ -590,7 +588,7 @@ impl DPEventLoop {
               );
 
               reader_proxy.multicast_locator_list = get_local_multicast_locators(
-                get_spdp_well_known_multicast_port(self.domain_info.domain_id),
+                spdp_well_known_multicast_port(self.domain_info.domain_id),
               );
             }
             // common processing for SPDP and SEDP
@@ -723,7 +721,7 @@ impl DPEventLoop {
     match self.discovery_db.read() {
       Ok(db) => match self.ddscache.write() {
         Ok(mut ddsc) => {
-          for topic in db.get_all_topics() {
+          for topic in db.all_topics() {
             // TODO: how do you know when topic is keyed and is not
             let topic_kind = match &topic.topic_data.key {
               Some(_) => TopicKind::WithKey,
@@ -1015,7 +1013,7 @@ mod tests {
   //     //new_reader.set_qos(&somePolicies).unwrap();
   //     new_reader.matched_writer_add(GUID::default(),
   // EntityId::ENTITYID_UNKNOWN, vec![], vec![]);     reader_guids.
-  // push(new_reader.get_guid().clone());     info!("\nSent reader number {}:
+  // push(new_reader.guid().clone());     info!("\nSent reader number {}:
   // {:?}\n", i, &new_reader);     sender_add_reader.send(new_reader).
   // unwrap();     std::thread::sleep(Duration::from_millis(100));
   //   }

--- a/src/dds/message_receiver.rs
+++ b/src/dds/message_receiver.rs
@@ -112,7 +112,7 @@ impl MessageReceiver {
   }
 
   pub fn add_reader(&mut self, new_reader: Reader) {
-    let eid = new_reader.get_guid().entity_id;
+    let eid = new_reader.guid().entity_id;
     match self.available_readers.entry(eid) {
       Entry::Occupied(_) => warn!("Already have Reader {:?} - not adding.", eid),
       e => {
@@ -125,7 +125,7 @@ impl MessageReceiver {
     self.available_readers.remove(&old_reader_guid.entity_id)
   }
 
-  pub fn get_reader_mut(&mut self, reader_id: EntityId) -> Option<&mut Reader> {
+  pub fn reader_mut(&mut self, reader_id: EntityId) -> Option<&mut Reader> {
     self.available_readers.get_mut(&reader_id)
   }
 
@@ -141,7 +141,7 @@ impl MessageReceiver {
         .available_readers
         .get(&reader_id)
         .unwrap()
-        .get_history_cache_change_data(sequence_number)
+        .history_cache_change_data(sequence_number)
         .unwrap(),
     )
   }
@@ -157,7 +157,7 @@ impl MessageReceiver {
       .available_readers
       .get(&reader_id)
       .unwrap()
-      .get_history_cache_change(sequence_number)
+      .history_cache_change(sequence_number)
       .unwrap()
   }
 
@@ -170,7 +170,7 @@ impl MessageReceiver {
       .available_readers
       .get(&reader_id)
       .unwrap()
-      .get_history_cache_sequence_start_and_end_numbers()
+      .history_cache_sequence_start_and_end_numbers()
   }
 
   // pub fn handle_discovery_msg(&mut self, msg: Bytes) {
@@ -256,7 +256,7 @@ impl MessageReceiver {
             .filter(|r| {
               r.contains_writer(data.writer_id)
                 || (data.writer_id == EntityId::ENTITYID_SPDP_BUILTIN_PARTICIPANT_WRITER
-                  && r.get_entity_id() == EntityId::ENTITYID_SPDP_BUILTIN_PARTICIPANT_READER)
+                  && r.entity_id() == EntityId::ENTITYID_SPDP_BUILTIN_PARTICIPANT_READER)
             })
           {
             debug!(
@@ -265,7 +265,7 @@ impl MessageReceiver {
             );
             reader.handle_data_msg(data.clone(), data_flags, mr_state.clone());
           }
-        } else if let Some(target_reader) = self.get_reader_mut(data.reader_id) {
+        } else if let Some(target_reader) = self.reader_mut(data.reader_id) {
           target_reader.handle_data_msg(data, data_flags, mr_state);
         }
       }
@@ -284,7 +284,7 @@ impl MessageReceiver {
               mr_state.clone(),
             );
           }
-        } else if let Some(target_reader) = self.get_reader_mut(heartbeat.reader_id) {
+        } else if let Some(target_reader) = self.reader_mut(heartbeat.reader_id) {
           target_reader.handle_heartbeat_msg(
             heartbeat,
             flags.contains(HEARTBEAT_Flags::Final),
@@ -293,7 +293,7 @@ impl MessageReceiver {
         }
       }
       EntitySubmessage::Gap(gap, _flags) => {
-        if let Some(target_reader) = self.get_reader_mut(gap.reader_id) {
+        if let Some(target_reader) = self.reader_mut(gap.reader_id) {
           target_reader.handle_gap_msg(gap, mr_state);
         }
       }
@@ -312,7 +312,7 @@ impl MessageReceiver {
         }
       }
       EntitySubmessage::DataFrag(datafrag, flags) => {
-        if let Some(target_reader) = self.get_reader_mut(datafrag.reader_id) {
+        if let Some(target_reader) = self.reader_mut(datafrag.reader_id) {
           target_reader.handle_datafrag_msg(datafrag, flags, mr_state);
         }
       }
@@ -327,7 +327,7 @@ impl MessageReceiver {
           {
             reader.handle_heartbeatfrag_msg(heartbeatfrag.clone(), mr_state.clone());
           }
-        } else if let Some(target_reader) = self.get_reader_mut(heartbeatfrag.reader_id) {
+        } else if let Some(target_reader) = self.reader_mut(heartbeatfrag.reader_id) {
           target_reader.handle_heartbeatfrag_msg(heartbeatfrag, mr_state);
         }
       }

--- a/src/dds/no_key/datareader.rs
+++ b/src/dds/no_key/datareader.rs
@@ -470,8 +470,8 @@ where
   //   self.keyed_datareader.set_qos(policy)
   // }
 
-  fn get_qos(&self) -> QosPolicies {
-    self.keyed_datareader.get_qos()
+  fn qos(&self) -> QosPolicies {
+    self.keyed_datareader.qos()
   }
 }
 
@@ -480,7 +480,7 @@ where
   D: DeserializeOwned,
   DA: DeserializerAdapter<D>,
 {
-  fn get_guid(&self) -> GUID {
-    self.keyed_datareader.get_guid()
+  fn guid(&self) -> GUID {
+    self.keyed_datareader.guid()
   }
 }

--- a/src/dds/no_key/datawriter.rs
+++ b/src/dds/no_key/datawriter.rs
@@ -272,10 +272,10 @@ where
   /// let topic = domain_participant.create_topic("some_topic".to_string(), "SomeType".to_string(), &qos, TopicKind::NoKey).unwrap();
   /// let data_writer = publisher.create_datawriter_no_key::<SomeType, CDRSerializerAdapter<_>>(topic.clone(), None).unwrap();
   ///
-  /// assert_eq!(&topic, data_writer.get_topic());
+  /// assert_eq!(&topic, data_writer.topic());
   /// ```
-  pub fn get_topic(&self) -> &Topic {
-    self.keyed_datawriter.get_topic()
+  pub fn topic(&self) -> &Topic {
+    self.keyed_datawriter.topic()
   }
 
   /// Publisher this DataWriter is connected to.
@@ -301,10 +301,10 @@ where
   /// let topic = domain_participant.create_topic("some_topic".to_string(), "SomeType".to_string(), &qos, TopicKind::NoKey).unwrap();
   /// let data_writer = publisher.create_datawriter_no_key::<SomeType, CDRSerializerAdapter<_>>(topic, None).unwrap();
   ///
-  /// assert_eq!(&publisher, data_writer.get_publisher());
+  /// assert_eq!(&publisher, data_writer.publisher());
   /// ```
-  pub fn get_publisher(&self) -> &Publisher {
-    self.keyed_datawriter.get_publisher()
+  pub fn publisher(&self) -> &Publisher {
+    self.keyed_datawriter.publisher()
   }
 
   /// Manually asserts liveliness if QoS agrees
@@ -402,8 +402,8 @@ where
 }
 
 impl<D: Serialize, SA: SerializerAdapter<D>> RTPSEntity for DataWriter<D, SA> {
-  fn get_guid(&self) -> GUID {
-    self.keyed_datawriter.get_guid()
+  fn guid(&self) -> GUID {
+    self.keyed_datawriter.guid()
   }
 }
 
@@ -412,8 +412,8 @@ impl<D: Serialize, SA: SerializerAdapter<D>> HasQoSPolicy for DataWriter<D, SA> 
   //   self.keyed_datawriter.set_qos(policy)
   // }
 
-  fn get_qos(&self) -> QosPolicies {
-    self.keyed_datawriter.get_qos()
+  fn qos(&self) -> QosPolicies {
+    self.keyed_datawriter.qos()
   }
 }
 

--- a/src/dds/no_key/wrappers.rs
+++ b/src/dds/no_key/wrappers.rs
@@ -40,7 +40,7 @@ impl<D> Deref for NoKeyWrapper<D> {
 
 impl<D> Keyed for NoKeyWrapper<D> {
   type K = ();
-  fn get_key(&self) {}
+  fn key(&self) {}
 }
 
 impl<'de, D> Deserialize<'de> for NoKeyWrapper<D>

--- a/src/dds/qos.rs
+++ b/src/dds/qos.rs
@@ -13,7 +13,7 @@ use crate::{
 /// Trait that is implemented by all necessary DDS Entities that are required to
 /// provide QosPolicies.
 pub trait HasQoSPolicy {
-  fn get_qos(&self) -> QosPolicies;
+  fn qos(&self) -> QosPolicies;
 }
 
 /// Trait that is implemented by all necessary DDS Entities that are required to

--- a/src/dds/rtps_reader_proxy.rs
+++ b/src/dds/rtps_reader_proxy.rs
@@ -11,7 +11,7 @@ use crate::{
   discovery::data_types::topic_data::DiscoveredReaderData,
   messages::submessages::submessage::AckSubmessage,
   network::{
-    constant::{get_user_traffic_multicast_port, get_user_traffic_unicast_port},
+    constant::{user_traffic_multicast_port, user_traffic_unicast_port},
     util::{get_local_multicast_locators, get_local_unicast_socket_address},
   },
   structure::{
@@ -84,10 +84,10 @@ impl RtpsReaderProxy {
     participant_id: u16,
   ) -> RtpsReaderProxy {
     let unicast_locator_list =
-      get_local_unicast_socket_address(get_user_traffic_unicast_port(domain_id, participant_id));
+      get_local_unicast_socket_address(user_traffic_unicast_port(domain_id, participant_id));
 
     let multicast_locator_list =
-      get_local_multicast_locators(get_user_traffic_multicast_port(domain_id));
+      get_local_multicast_locators(user_traffic_multicast_port(domain_id));
 
     RtpsReaderProxy {
       remote_reader_guid: reader.guid,

--- a/src/dds/rtps_writer_proxy.rs
+++ b/src/dds/rtps_writer_proxy.rs
@@ -87,7 +87,7 @@ impl RtpsWriterProxy {
     self.changes.is_empty()
   }
 
-  pub fn get_missing_sequence_numbers(
+  pub fn missing_sequence_numbers(
     &self,
     hb_first_sn: SequenceNumber,
     hb_last_sn: SequenceNumber,

--- a/src/dds/topic.rs
+++ b/src/dds/topic.rs
@@ -5,9 +5,9 @@ pub use crate::structure::topic_kind::TopicKind;
 
 /// Trait estimate of DDS 2.2.2.3.1 TopicDescription Class
 pub trait TopicDescription {
-  fn get_participant(&self) -> Option<DomainParticipant>;
-  fn get_type(&self) -> TypeDesc; // This replaces get_type_name() from spec
-  fn get_name(&self) -> String;
+  fn participant(&self) -> Option<DomainParticipant>;
+  fn get_type(&self) -> TypeDesc; // This replaces type_name() from spec
+  fn name(&self) -> String;
 }
 
 /// DDS Topic
@@ -52,8 +52,8 @@ impl Topic {
     }
   }
 
-  fn get_participant(&self) -> Option<DomainParticipant> {
-    self.inner.get_participant()
+  fn participant(&self) -> Option<DomainParticipant> {
+    self.inner.participant()
   }
 
   // TODO: Confusing combination of borrows and owns
@@ -61,8 +61,8 @@ impl Topic {
     self.inner.get_type()
   }
 
-  fn get_name(&self) -> String {
-    self.inner.get_name()
+  fn name(&self) -> String {
+    self.inner.name()
   }
 
   /// Gets Topics TopicKind
@@ -111,8 +111,8 @@ impl Debug for Topic {
 impl TopicDescription for Topic {
   /// Gets [DomainParticipant](struct.DomainParticipant.html) if it is still
   /// alive.
-  fn get_participant(&self) -> Option<DomainParticipant> {
-    self.get_participant()
+  fn participant(&self) -> Option<DomainParticipant> {
+    self.participant()
   }
 
   /// Gets type description of this Topic
@@ -121,14 +121,14 @@ impl TopicDescription for Topic {
   }
 
   /// Gets name of this topic
-  fn get_name(&self) -> String {
-    self.get_name()
+  fn name(&self) -> String {
+    self.name()
   }
 }
 
 impl HasQoSPolicy for Topic {
-  fn get_qos(&self) -> QosPolicies {
-    self.inner.get_qos()
+  fn qos(&self) -> QosPolicies {
+    self.inner.qos()
   }
 }
 
@@ -164,7 +164,7 @@ impl InnerTopic {
     }
   }
 
-  fn get_participant(&self) -> Option<DomainParticipant> {
+  fn participant(&self) -> Option<DomainParticipant> {
     self.my_domainparticipant.clone().upgrade()
   }
 
@@ -172,7 +172,7 @@ impl InnerTopic {
     self.my_typedesc.clone()
   }
 
-  fn get_name(&self) -> String {
+  fn name(&self) -> String {
     self.my_name.to_string()
   }
 
@@ -187,20 +187,20 @@ impl InnerTopic {
 
 impl PartialEq for InnerTopic {
   fn eq(&self, other: &Self) -> bool {
-    self.get_participant() == other.get_participant()
+    self.participant() == other.participant()
       && self.get_type() == other.get_type()
-      && self.get_name() == other.get_name()
-      && self.get_qos() == other.get_qos()
+      && self.name() == other.name()
+      && self.qos() == other.qos()
       && self.topic_kind == other.topic_kind
   }
 }
 
 impl Debug for InnerTopic {
   fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-    f.write_fmt(format_args!("{:?}", self.get_participant()))?;
-    f.write_fmt(format_args!("Topic name: {}", self.get_name()))?;
+    f.write_fmt(format_args!("{:?}", self.participant()))?;
+    f.write_fmt(format_args!("Topic name: {}", self.name()))?;
     f.write_fmt(format_args!("Topic type: {:?}", self.get_type()))?;
-    f.write_fmt(format_args!("Topic QoS: {:?} ", self.get_qos()))
+    f.write_fmt(format_args!("Topic QoS: {:?} ", self.qos()))
   }
 }
 
@@ -208,8 +208,8 @@ impl Debug for InnerTopic {
 impl TopicDescription for InnerTopic {
   /// Gets [DomainParticipant](struct.DomainParticipant.html) if it is still
   /// alive.
-  fn get_participant(&self) -> Option<DomainParticipant> {
-    self.get_participant()
+  fn participant(&self) -> Option<DomainParticipant> {
+    self.participant()
   }
 
   /// Gets type description of this Topic
@@ -218,8 +218,8 @@ impl TopicDescription for InnerTopic {
   }
 
   /// Gets name of this topic
-  fn get_name(&self) -> String {
-    self.get_name()
+  fn name(&self) -> String {
+    self.name()
   }
 }
 
@@ -230,7 +230,7 @@ impl HasQoSPolicy for InnerTopic {
   //   Ok(())
   // }
 
-  fn get_qos(&self) -> QosPolicies {
+  fn qos(&self) -> QosPolicies {
     self.my_qos_policies.clone()
   }
 }

--- a/src/dds/traits/key.rs
+++ b/src/dds/traits/key.rs
@@ -35,7 +35,7 @@ pub trait Keyed {
   // where <D as Keyed>::K : Key,
   type K;
 
-  fn get_key(&self) -> Self::K;
+  fn key(&self) -> Self::K;
 
   // provided method (TODO: what for?)
   fn get_hash(&self) -> u64
@@ -43,7 +43,7 @@ pub trait Keyed {
     Self::K: Key,
   {
     let mut hasher = DefaultHasher::new();
-    self.get_key().hash(&mut hasher);
+    self.key().hash(&mut hasher);
     hasher.finish()
   }
 }
@@ -153,8 +153,8 @@ impl Key for () {
 /// This is required internally for the implementation of NoKey topics.
 impl<D: Keyed> Keyed for &D {
   type K = D::K;
-  fn get_key(&self) -> Self::K {
-    (*self).get_key()
+  fn key(&self) -> Self::K {
+    (*self).key()
   }
 }
 
@@ -186,7 +186,7 @@ pub struct BuiltInTopicKey {
 }
 
 impl BuiltInTopicKey {
-  pub fn get_random_key() -> BuiltInTopicKey {
+  pub fn random_key() -> BuiltInTopicKey {
     let mut rng = rand::thread_rng();
     BuiltInTopicKey {
       value: [rng.gen(), rng.gen(), rng.gen()],

--- a/src/dds/with_key/datasample.rs
+++ b/src/dds/with_key/datasample.rs
@@ -33,12 +33,12 @@ where
 
   // convenience shorthand to get the key directly, without digging out the
   // "value"
-  pub fn get_key(&self) -> D::K
+  pub fn key(&self) -> D::K
   where
     <D as Keyed>::K: Key,
   {
     match &self.value {
-      Ok(d) => d.get_key(),
+      Ok(d) => d.key(),
       Err(k) => k.clone(),
     }
   } // fn

--- a/src/dds/with_key/datawriter.rs
+++ b/src/dds/with_key/datawriter.rs
@@ -68,7 +68,7 @@ pub type DataWriterCdr<D> = DataWriter<D, CDRSerializerAdapter<D>>;
 /// impl Keyed for SomeType {
 ///   type K = i32;
 ///
-///   fn get_key(&self) -> Self::K {
+///   fn key(&self) -> Self::K {
 ///     self.a
 ///   }
 /// }
@@ -98,9 +98,8 @@ where
   fn drop(&mut self) {
     match self
       .discovery_command
-      .send(DiscoveryCommand::RemoveLocalWriter {
-        guid: self.get_guid(),
-      }) {
+      .send(DiscoveryCommand::RemoveLocalWriter { guid: self.guid() })
+    {
       Ok(_) => {}
 
       // This is fairly normal at shutdown, as the other end is down already.
@@ -136,7 +135,7 @@ where
       None => EntityId::ENTITYID_UNKNOWN,
     };
 
-    let dp = match publisher.get_participant() {
+    let dp = match publisher.participant() {
       Some(dp) => dp,
       None => {
         return log_and_err_precondition_not_met!(
@@ -145,14 +144,14 @@ where
       }
     };
 
-    let my_guid = GUID::new_with_prefix_and_id(dp.get_guid_prefix(), entity_id);
+    let my_guid = GUID::new_with_prefix_and_id(dp.guid_prefix(), entity_id);
 
     match dds_cache.write() {
-      Ok(mut cache) => cache.add_new_topic(topic.get_name(), TopicKind::NoKey, topic.get_type()),
+      Ok(mut cache) => cache.add_new_topic(topic.name(), TopicKind::NoKey, topic.get_type()),
       Err(e) => panic!("DDSCache is poisoned. {:?}", e),
     };
 
-    if let Some(lv) = topic.get_qos().liveliness {
+    if let Some(lv) = topic.qos().liveliness {
       match lv {
         Liveliness::Automatic { lease_duration: _ } => (),
         Liveliness::ManualByParticipant { lease_duration: _ } => {
@@ -166,7 +165,7 @@ where
         Liveliness::ManualByTopic { lease_duration: _ } => (),
       }
     };
-    let qos = topic.get_qos();
+    let qos = topic.qos();
     Ok(DataWriter {
       my_publisher: publisher,
       my_topic: topic,
@@ -208,7 +207,7 @@ where
   /// impl Keyed for SomeType {
   ///   type K = i32;
   ///
-  ///   fn get_key(&self) -> Self::K {
+  ///   fn key(&self) -> Self::K {
   ///     self.a
   ///   }
   /// }
@@ -222,7 +221,7 @@ where
 
   // TODO: What is this function? To what part of DDS spec does it correspond to?
   pub fn refresh_manual_liveliness(&self) {
-    if let Some(lv) = self.get_qos().liveliness {
+    if let Some(lv) = self.qos().liveliness {
       match lv {
         Liveliness::Automatic { lease_duration: _ } => (),
         Liveliness::ManualByParticipant { lease_duration: _ } => {
@@ -263,7 +262,7 @@ where
   /// impl Keyed for SomeType {
   ///   type K = i32;
   ///
-  ///   fn get_key(&self) -> Self::K {
+  ///   fn key(&self) -> Self::K {
   ///     self.a
   ///   }
   /// }
@@ -287,7 +286,7 @@ where
       source_timestamp,
     };
 
-    let timeout = match self.get_qos().reliability() {
+    let timeout = match self.qos().reliability() {
       Some(Reliability::Reliable { max_blocking_time }) => Some(max_blocking_time),
       _ => None,
     };
@@ -300,7 +299,7 @@ where
       Err(e) => {
         warn!(
           "Failed to write new data: topic={:?}  reason={:?}  timeout={:?}",
-          self.my_topic.get_name(),
+          self.my_topic.name(),
           e,
           timeout,
         );
@@ -344,7 +343,7 @@ where
   /// impl Keyed for SomeType {
   ///   type K = i32;
   ///
-  ///   fn get_key(&self) -> Self::K {
+  ///   fn key(&self) -> Self::K {
   ///     self.a
   ///   }
   /// }
@@ -413,7 +412,7 @@ where
   /// impl Keyed for SomeType {
   ///   type K = i32;
   ///
-  ///   fn get_key(&self) -> Self::K {
+  ///   fn key(&self) -> Self::K {
   ///     self.a
   ///   }
   /// }
@@ -432,7 +431,7 @@ where
     match self
       .cc_upload
       .try_send(WriterCommand::ResetOfferedDeadlineMissedStatus {
-        writer_guid: self.get_guid(),
+        writer_guid: self.guid(),
       }) {
       Ok(_) => (),
       Err(e) => error!("Unable to send ResetOfferedDeadlineMissedStatus. {:?}", e),
@@ -463,7 +462,7 @@ where
   /// impl Keyed for SomeType {
   ///   type K = i32;
   ///
-  ///   fn get_key(&self) -> Self::K {
+  ///   fn key(&self) -> Self::K {
   ///     self.a
   ///   }
   /// }
@@ -504,7 +503,7 @@ where
   /// impl Keyed for SomeType {
   ///   type K = i32;
   ///
-  ///   fn get_key(&self) -> Self::K {
+  ///   fn key(&self) -> Self::K {
   ///     self.a
   ///   }
   /// }
@@ -532,7 +531,7 @@ where
     match self
       .cc_upload
       .try_send(WriterCommand::ResetOfferedDeadlineMissedStatus {
-        writer_guid: self.get_guid(),
+        writer_guid: self.guid(),
       }) {
       Ok(_) => (),
       Err(e) => error!("Unable to send ResetOfferedDeadlineMissedStatus. {:?}", e),
@@ -564,7 +563,7 @@ where
   /// impl Keyed for SomeType {
   ///   type K = i32;
   ///
-  ///   fn get_key(&self) -> Self::K {
+  ///   fn key(&self) -> Self::K {
   ///     self.a
   ///   }
   /// }
@@ -606,7 +605,7 @@ where
   /// impl Keyed for SomeType {
   ///   type K = i32;
   ///
-  ///   fn get_key(&self) -> Self::K {
+  ///   fn key(&self) -> Self::K {
   ///     self.a
   ///   }
   /// }
@@ -649,7 +648,7 @@ where
   /// impl Keyed for SomeType {
   ///   type K = i32;
   ///
-  ///   fn get_key(&self) -> Self::K {
+  ///   fn key(&self) -> Self::K {
   ///     self.a
   ///   }
   /// }
@@ -658,9 +657,9 @@ where
   /// let topic = domain_participant.create_topic("some_topic".to_string(), "SomeType".to_string(), &qos, TopicKind::WithKey).unwrap();
   /// let data_writer = publisher.create_datawriter::<SomeType, CDRSerializerAdapter<_>>(topic.clone(), None).unwrap();
   ///
-  /// assert_eq!(data_writer.get_topic(), &topic);
+  /// assert_eq!(data_writer.topic(), &topic);
   /// ```
-  pub fn get_topic(&self) -> &Topic {
+  pub fn topic(&self) -> &Topic {
     &self.my_topic
   }
 
@@ -686,7 +685,7 @@ where
   /// impl Keyed for SomeType {
   ///   type K = i32;
   ///
-  ///   fn get_key(&self) -> Self::K {
+  ///   fn key(&self) -> Self::K {
   ///     self.a
   ///   }
   /// }
@@ -695,8 +694,8 @@ where
   /// let topic = domain_participant.create_topic("some_topic".to_string(), "SomeType".to_string(), &qos, TopicKind::WithKey).unwrap();
   /// let data_writer = publisher.create_datawriter::<SomeType, CDRSerializerAdapter<_>>(topic, None).unwrap();
   ///
-  /// assert_eq!(data_writer.get_publisher(), &publisher);
-  pub fn get_publisher(&self) -> &Publisher {
+  /// assert_eq!(data_writer.publisher(), &publisher);
+  pub fn publisher(&self) -> &Publisher {
     &self.my_publisher
   }
 
@@ -722,7 +721,7 @@ where
   /// impl Keyed for SomeType {
   ///   type K = i32;
   ///
-  ///   fn get_key(&self) -> Self::K {
+  ///   fn key(&self) -> Self::K {
   ///     self.a
   ///   }
   /// }
@@ -740,12 +739,12 @@ where
   pub fn assert_liveliness(&self) -> Result<()> {
     self.refresh_manual_liveliness();
 
-    match self.get_qos().liveliness {
+    match self.qos().liveliness {
       Some(Liveliness::ManualByTopic { lease_duration: _ }) => {
         self
           .discovery_command
           .send(DiscoveryCommand::AssertTopicLiveliness {
-            writer_guid: self.get_guid(),
+            writer_guid: self.guid(),
             manual_assertion: true, // by definition of this function
           })
           .unwrap_or_else(|e| error!("assert_liveness - Failed to send DiscoveryCommand. {:?}", e))
@@ -778,7 +777,7 @@ where
   /// impl Keyed for SomeType {
   ///   type K = i32;
   ///
-  ///   fn get_key(&self) -> Self::K {
+  ///   fn key(&self) -> Self::K {
   ///     self.a
   ///   }
   /// }
@@ -824,7 +823,7 @@ where
   /// impl Keyed for SomeType {
   ///   type K = i32;
   ///
-  ///   fn get_key(&self) -> Self::K {
+  ///   fn key(&self) -> Self::K {
   ///     self.a
   ///   }
   /// }
@@ -886,7 +885,7 @@ where
   D: Keyed + Serialize,
   SA: SerializerAdapter<D>,
 {
-  fn get_guid(&self) -> GUID {
+  fn guid(&self) -> GUID {
     self.my_guid
   }
 }
@@ -902,7 +901,7 @@ where
   //   Ok(())
   // }
 
-  fn get_qos(&self) -> QosPolicies {
+  fn qos(&self) -> QosPolicies {
     self.qos_policy.clone()
   }
 }
@@ -995,7 +994,7 @@ mod tests {
       b: "Fobar".to_string(),
     };
 
-    let key = &data.get_key().hash_key();
+    let key = &data.key().hash_key();
     info!("key: {:?}", key);
 
     data_writer
@@ -1004,7 +1003,7 @@ mod tests {
 
     thread::sleep(Duration::from_millis(100));
     data_writer
-      .dispose(data.get_key(), None)
+      .dispose(data.key(), None)
       .expect("Unable to dispose data");
 
     // TODO: verify that dispose is sent correctly

--- a/src/dds/writer.rs
+++ b/src/dds/writer.rs
@@ -249,21 +249,21 @@ impl Writer {
 
   /// To know when token represents a writer we should look entity attribute
   /// kind this entity token can be used in DataWriter -> Writer mio::channel.
-  pub fn get_entity_token(&self) -> Token {
-    self.get_guid().entity_id.as_token()
+  pub fn entity_token(&self) -> Token {
+    self.guid().entity_id.as_token()
   }
 
   /// This token is used in timed event mio::channel HearbeatHandler ->
   /// dpEventwrapper
-  pub fn get_timed_event_entity_token(&self) -> Token {
-    self.get_guid().entity_id.as_alt_token()
+  pub fn timed_event_entity_token(&self) -> Token {
+    self.guid().entity_id.as_alt_token()
   }
 
   pub fn is_reliable(&self) -> bool {
     self.qos_policies.reliability.is_some()
   }
 
-  pub fn get_local_readers(&self) -> Vec<EntityId> {
+  pub fn local_readers(&self) -> Vec<EntityId> {
     let min = GUID::new_with_prefix_and_id(self.my_guid.guid_prefix, EntityId::MIN);
     let max = GUID::new_with_prefix_and_id(self.my_guid.guid_prefix, EntityId::MAX);
 
@@ -473,7 +473,7 @@ impl Writer {
 
     // setting first change sequence number according to our qos (not offering more
     // than our QOS says)
-    self.first_change_sequence_number = match self.get_qos().history {
+    self.first_change_sequence_number = match self.qos().history {
       None => self.last_change_sequence_number, // default: depth = 1
 
       Some(History::KeepAll) =>
@@ -492,7 +492,7 @@ impl Writer {
 
     // create new CacheChange from DDSData
     let new_cache_change = CacheChange::new(
-      self.get_guid(),
+      self.guid(),
       self.last_change_sequence_number,
       source_timestamp,
       data,
@@ -562,7 +562,7 @@ impl Writer {
         .add_header_and_build(self.my_guid.guid_prefix);
       debug!(
         "Writer {:?} topic={:} HEARTBEAT {:?}",
-        self.get_guid().entity_id,
+        self.guid().entity_id,
         self.topic_name(),
         hb_message
       );
@@ -585,7 +585,7 @@ impl Writer {
         if !self.is_reliable() {
           warn!(
             "Writer {:x?} is best effort! It should not handle acknack messages!",
-            self.get_entity_id()
+            self.entity_id()
           );
           return;
         }
@@ -1052,7 +1052,7 @@ impl Writer {
 }
 
 impl RTPSEntity for Writer {
-  fn get_guid(&self) -> GUID {
+  fn guid(&self) -> GUID {
     self.my_guid
   }
 }
@@ -1064,7 +1064,7 @@ impl Endpoint for Writer {
 }
 
 impl HasQoSPolicy for Writer {
-  fn get_qos(&self) -> QosPolicies {
+  fn qos(&self) -> QosPolicies {
     self.qos_policies.clone()
   }
 }

--- a/src/discovery/data_types/spdp_participant_data.rs
+++ b/src/discovery/data_types/spdp_participant_data.rs
@@ -120,18 +120,18 @@ impl SpdpDiscoveredParticipantData {
     participant: &DomainParticipant,
     lease_duration: Duration,
   ) -> SpdpDiscoveredParticipantData {
-    let spdp_multicast_port = get_spdp_well_known_multicast_port(participant.domain_id());
+    let spdp_multicast_port = spdp_well_known_multicast_port(participant.domain_id());
     let metatraffic_multicast_locators = get_local_multicast_locators(spdp_multicast_port);
 
     let spdp_unicast_port =
-      get_spdp_well_known_unicast_port(participant.domain_id(), participant.participant_id());
+      spdp_well_known_unicast_port(participant.domain_id(), participant.participant_id());
     let metatraffic_unicast_locators = get_local_unicast_socket_address(spdp_unicast_port);
 
-    let multicast_port = get_user_traffic_multicast_port(participant.domain_id());
+    let multicast_port = user_traffic_multicast_port(participant.domain_id());
     let default_multicast_locators = get_local_multicast_locators(multicast_port);
 
     let unicast_port =
-      get_user_traffic_unicast_port(participant.domain_id(), participant.participant_id());
+      user_traffic_unicast_port(participant.domain_id(), participant.participant_id());
     let default_unicast_locators = get_local_unicast_socket_address(unicast_port);
 
     let builtin_endpoints = BuiltinEndpointSet::DISC_BUILTIN_ENDPOINT_PARTICIPANT_ANNOUNCER
@@ -150,7 +150,7 @@ impl SpdpDiscoveredParticipantData {
       protocol_version: ProtocolVersion::PROTOCOLVERSION_2_3,
       vendor_id: VendorId::THIS_IMPLEMENTATION,
       expects_inline_qos: false,
-      participant_guid: participant.get_guid(),
+      participant_guid: participant.guid(),
       metatraffic_unicast_locators,
       metatraffic_multicast_locators,
       default_unicast_locators,
@@ -192,7 +192,7 @@ impl Serialize for SpdpDiscoveredParticipantData {
 
 impl Keyed for SpdpDiscoveredParticipantData {
   type K = SpdpDiscoveredParticipantDataKey;
-  fn get_key(&self) -> Self::K {
+  fn key(&self) -> Self::K {
     SpdpDiscoveredParticipantDataKey(self.participant_guid)
   }
 }

--- a/src/discovery/data_types/topic_data.rs
+++ b/src/discovery/data_types/topic_data.rs
@@ -26,7 +26,7 @@ use crate::{
     with_key::datawriter::DataWriter,
   },
   discovery::content_filter_property::ContentFilterProperty,
-  network::{constant::get_user_traffic_unicast_port, util::get_local_unicast_socket_address},
+  network::{constant::user_traffic_unicast_port, util::get_local_unicast_socket_address},
   serialization::{
     builtin_data_deserializer::BuiltinDataDeserializer,
     builtin_data_serializer::BuiltinDataSerializer,
@@ -311,14 +311,14 @@ impl DiscoveredReaderData {
     dp: &DomainParticipant,
     topic: &Topic,
   ) -> DiscoveredReaderData {
-    let reader_proxy = ReaderProxy::new(reader.get_guid());
+    let reader_proxy = ReaderProxy::new(reader.guid());
     let mut subscription_topic_data = SubscriptionBuiltinTopicData::new(
-      reader.get_guid(),
-      topic.get_name(),
+      reader.guid(),
+      topic.name(),
       topic.get_type().name().to_string(),
-      &topic.get_qos(),
+      &topic.qos(),
     );
-    subscription_topic_data.set_participant_key(dp.get_guid());
+    subscription_topic_data.set_participant_key(dp.guid());
 
     DiscoveredReaderData {
       reader_proxy,
@@ -359,7 +359,7 @@ impl Key for DiscoveredReaderDataKey {}
 
 impl Keyed for DiscoveredReaderData {
   type K = DiscoveredReaderDataKey;
-  fn get_key(&self) -> Self::K {
+  fn key(&self) -> Self::K {
     DiscoveredReaderDataKey(self.subscription_topic_data.key)
   }
 }
@@ -602,7 +602,7 @@ impl Key for DiscoveredWriterDataKey {}
 impl Keyed for DiscoveredWriterData {
   type K = DiscoveredWriterDataKey;
 
-  fn get_key(&self) -> Self::K {
+  fn key(&self) -> Self::K {
     DiscoveredWriterDataKey(self.publication_topic_data.key)
   }
 }
@@ -613,18 +613,18 @@ impl DiscoveredWriterData {
     topic: &Topic,
     dp: &DomainParticipant,
   ) -> DiscoveredWriterData {
-    let unicast_port = get_user_traffic_unicast_port(dp.domain_id(), dp.participant_id());
+    let unicast_port = user_traffic_unicast_port(dp.domain_id(), dp.participant_id());
     let unicast_addresses = get_local_unicast_socket_address(unicast_port);
 
-    let writer_proxy = WriterProxy::new(writer.get_guid(), vec![], unicast_addresses);
+    let writer_proxy = WriterProxy::new(writer.guid(), vec![], unicast_addresses);
     let mut publication_topic_data = PublicationBuiltinTopicData::new(
-      writer.get_guid(),
-      dp.get_guid(),
-      topic.get_name(),
+      writer.guid(),
+      dp.guid(),
+      topic.name(),
       topic.get_type().name().to_string(),
     );
 
-    publication_topic_data.read_qos(&topic.get_qos());
+    publication_topic_data.read_qos(&topic.qos());
 
     DiscoveredWriterData {
       last_updated: Instant::now(),
@@ -710,7 +710,7 @@ pub struct TopicBuiltinTopicData {
 }
 
 impl HasQoSPolicy for TopicBuiltinTopicData {
-  fn get_qos(&self) -> QosPolicies {
+  fn qos(&self) -> QosPolicies {
     QosPolicies {
       durability: self.durability,
       presentation: self.presentation,
@@ -771,11 +771,11 @@ impl DiscoveredTopicData {
     }
   }
 
-  pub fn get_topic_name(&self) -> &String {
+  pub fn topic_name(&self) -> &String {
     &self.topic_data.name
   }
 
-  pub fn get_type_name(&self) -> &String {
+  pub fn type_name(&self) -> &String {
     &self.topic_data.type_name
   }
 }
@@ -808,7 +808,7 @@ pub type DiscoveredTopicDataKey = GUID;
 impl Keyed for DiscoveredTopicData {
   type K = GUID;
 
-  fn get_key(&self) -> Self::K {
+  fn key(&self) -> Self::K {
     // topic should always have a name, if this crashes the problem is in the
     // overall logic (or message parsing)
     match self.topic_data.key {
@@ -860,7 +860,7 @@ pub struct ParticipantMessageData {
 impl Keyed for ParticipantMessageData {
   type K = ParticipantMessageDataKey;
 
-  fn get_key(&self) -> Self::K {
+  fn key(&self) -> Self::K {
     ParticipantMessageDataKey(self.guid, self.kind)
   }
 }

--- a/src/discovery/discovery_db.rs
+++ b/src/discovery/discovery_db.rs
@@ -259,7 +259,7 @@ impl DiscoveryDB {
     }
   }
 
-  pub fn get_participants(&self) -> impl Iterator<Item = &SpdpDiscoveredParticipantData> {
+  pub fn participants(&self) -> impl Iterator<Item = &SpdpDiscoveredParticipantData> {
     self.participant_proxies.values()
   }
 
@@ -275,15 +275,11 @@ impl DiscoveryDB {
     self.writers_updated = true;
   }
 
-  pub fn get_external_reader_proxies<'a>(
-    &'a self,
-  ) -> impl Iterator<Item = &DiscoveredReaderData> + 'a {
+  pub fn external_reader_proxies<'a>(&'a self) -> impl Iterator<Item = &DiscoveredReaderData> + 'a {
     self.external_topic_readers.values()
   }
 
-  pub fn get_external_writer_proxies<'a>(
-    &'a self,
-  ) -> impl Iterator<Item = &DiscoveredWriterData> + 'a {
+  pub fn external_writer_proxies<'a>(&'a self) -> impl Iterator<Item = &DiscoveredWriterData> + 'a {
     self.external_topic_writers.values()
   }
 
@@ -402,19 +398,19 @@ impl DiscoveryDB {
   pub fn update_topic_data_p(&mut self, topic: &Topic) {
     let topic_data = DiscoveredTopicData::new(TopicBuiltinTopicData {
       key: None,
-      name: topic.get_name(),
+      name: topic.name(),
       type_name: String::from(topic.get_type().name()),
-      durability: topic.get_qos().durability,
-      deadline: topic.get_qos().deadline,
-      latency_budget: topic.get_qos().latency_budget,
-      liveliness: topic.get_qos().liveliness,
-      reliability: topic.get_qos().reliability,
-      lifespan: topic.get_qos().lifespan,
-      destination_order: topic.get_qos().destination_order,
-      presentation: topic.get_qos().presentation,
-      history: topic.get_qos().history,
-      resource_limits: topic.get_qos().resource_limits,
-      ownership: topic.get_qos().ownership,
+      durability: topic.qos().durability,
+      deadline: topic.qos().deadline,
+      latency_budget: topic.qos().latency_budget,
+      liveliness: topic.qos().liveliness,
+      reliability: topic.qos().reliability,
+      lifespan: topic.qos().lifespan,
+      destination_order: topic.qos().destination_order,
+      presentation: topic.qos().presentation,
+      history: topic.qos().history,
+      resource_limits: topic.qos().resource_limits,
+      ownership: topic.qos().ownership,
     });
 
     self.update_topic_data(&topic_data);
@@ -451,11 +447,11 @@ impl DiscoveryDB {
 
     let mut subscription_data = SubscriptionBuiltinTopicData::new(
       reader_guid,
-      topic.get_name(),
+      topic.name(),
       topic.get_type().name().to_string(),
-      &topic.get_qos(),
+      &topic.qos(),
     );
-    subscription_data.set_participant_key(domain_participant.get_guid());
+    subscription_data.set_participant_key(domain_participant.guid());
 
     // TODO: possibly change content filter to dynamic value
     let content_filter = None;
@@ -502,7 +498,7 @@ impl DiscoveryDB {
     self.local_topic_writers.iter().map(|(_, p)| p)
   }
 
-  pub fn get_all_topics(&self) -> impl Iterator<Item = &DiscoveredTopicData> {
+  pub fn all_topics(&self) -> impl Iterator<Item = &DiscoveredTopicData> {
     self
       .topics
       .iter()
@@ -516,7 +512,7 @@ impl DiscoveryDB {
     &'a self,
     topic: &'a T,
   ) -> Vec<&DiscoveredReaderData> {
-    let topic_name = topic.get_name();
+    let topic_name = topic.name();
     self
       .local_topic_readers
       .iter()
@@ -646,7 +642,7 @@ mod tests {
     let reader1 = reader_proxy_data().unwrap();
     let mut reader1sub = subscription_builtin_topic_data().unwrap();
     reader1sub.set_key(reader1.remote_reader_guid);
-    reader1sub.set_topic_name(&topic.get_name());
+    reader1sub.set_topic_name(&topic.name());
     let dreader1 = DiscoveredReaderData {
       reader_proxy: reader1.clone(),
       subscription_topic_data: reader1sub.clone(),
@@ -657,7 +653,7 @@ mod tests {
     let reader2 = reader_proxy_data().unwrap();
     let mut reader2sub = subscription_builtin_topic_data().unwrap();
     reader2sub.set_key(reader2.remote_reader_guid);
-    reader2sub.set_topic_name(&topic2.get_name());
+    reader2sub.set_topic_name(&topic2.name());
     let dreader2 = DiscoveredReaderData {
       reader_proxy: reader2,
       subscription_topic_data: reader2sub,
@@ -702,7 +698,7 @@ mod tests {
       guid: GUID::dummy_test_guid(EntityKind::READER_NO_KEY_USER_DEFINED),
       notification_sender: notification_sender.clone(),
       status_sender: status_sender.clone(),
-      topic_name: topic.get_name(),
+      topic_name: topic.name(),
       qos_policy: QosPolicies::qos_none(),
       data_reader_command_receiver: reader_command_receiver1,
     };
@@ -732,7 +728,7 @@ mod tests {
       ), // GUID needs to be different in order to be added
       notification_sender,
       status_sender,
-      topic_name: topic.get_name(),
+      topic_name: topic.name(),
       qos_policy: QosPolicies::qos_none(),
       data_reader_command_receiver: reader_command_receiver2,
     };

--- a/src/network/constant.rs
+++ b/src/network/constant.rs
@@ -70,19 +70,19 @@ const D1: u16 = 10;
 const D2: u16 = 1;
 const D3: u16 = 11;
 
-pub fn get_spdp_well_known_multicast_port(domain_id: u16) -> u16 {
+pub fn spdp_well_known_multicast_port(domain_id: u16) -> u16 {
   PB + DG * domain_id + D0
 }
 
-pub fn get_spdp_well_known_unicast_port(domain_id: u16, participant_id: u16) -> u16 {
+pub fn spdp_well_known_unicast_port(domain_id: u16, participant_id: u16) -> u16 {
   PB + DG * domain_id + D1 + PG * participant_id
 }
 
-pub fn get_user_traffic_multicast_port(domain_id: u16) -> u16 {
+pub fn user_traffic_multicast_port(domain_id: u16) -> u16 {
   PB + DG * domain_id + D2
 }
 
-pub fn get_user_traffic_unicast_port(domain_id: u16, participant_id: u16) -> u16 {
+pub fn user_traffic_unicast_port(domain_id: u16, participant_id: u16) -> u16 {
   PB + DG * domain_id + D3 + PG * participant_id
 }
 

--- a/src/network/udp_listener.rs
+++ b/src/network/udp_listener.rs
@@ -170,7 +170,7 @@ impl UDPListener {
     }
     unsafe {
       // This is safe, because we just checked that there is enough capacity.
-      // We do not read undefined data, because next the recv call in get_messages()
+      // We do not read undefined data, because next the recv call in messages()
       // will overwrite this space and truncate the rest away.
       self.receive_buffer.set_len(MAX_MESSAGE_SIZE)
     }
@@ -181,7 +181,7 @@ impl UDPListener {
   }
 
   /// Get all messages waiting in the socket.
-  pub fn get_messages(&mut self) -> Vec<Bytes> {
+  pub fn messages(&mut self) -> Vec<Bytes> {
     // This code may seem slighlty non-sensical, if you do not know
     // how BytesMut works.
     let mut messages = Vec::with_capacity(4); // just a guess, should cover most cases

--- a/src/ros2/builtin_datatypes.rs
+++ b/src/ros2/builtin_datatypes.rs
@@ -45,11 +45,11 @@ impl NodeInfo {
     }
   }
 
-  pub fn get_namespace(&self) -> &str {
+  pub fn namespace(&self) -> &str {
     &self.node_namespace
   }
 
-  pub fn get_name(&self) -> &str {
+  pub fn name(&self) -> &str {
     &self.node_name
   }
 
@@ -162,7 +162,7 @@ impl Log {
   }
 
   /// Name of the rosout message
-  pub fn get_name(&self) -> &str {
+  pub fn name(&self) -> &str {
     &self.name
   }
 

--- a/src/ros2/builtin_topics.rs
+++ b/src/ros2/builtin_topics.rs
@@ -46,7 +46,7 @@ impl ROSDiscoveryTopic {
     ROSDiscoveryTopic::TYPE_NAME
   }
 
-  pub const fn get_qos() -> QosPolicies {
+  pub const fn qos() -> QosPolicies {
     ROSDiscoveryTopic::QOS
   }
 }
@@ -82,7 +82,7 @@ impl ParameterEventsTopic {
     ParameterEventsTopic::TYPE_NAME
   }
 
-  pub fn get_qos() -> QosPolicies {
+  pub fn qos() -> QosPolicies {
     ParameterEventsTopic::QOS
   }
 }
@@ -124,7 +124,7 @@ impl RosOutTopic {
     RosOutTopic::TYPE_NAME
   }
 
-  pub fn get_qos() -> QosPolicies {
+  pub fn qos() -> QosPolicies {
     RosOutTopic::QOS
   }
 }

--- a/src/ros2/ros_node.rs
+++ b/src/ros2/ros_node.rs
@@ -77,8 +77,8 @@ impl RosParticipant {
     self.inner.lock().unwrap().domain_participant.domain_id()
   }
 
-  pub fn get_discovered_topics(&self) -> Vec<DiscoveredTopicData> {
-    self.domain_participant().get_discovered_topics()
+  pub fn discovered_topics(&self) -> Vec<DiscoveredTopicData> {
+    self.domain_participant().discovered_topics()
   }
 
   pub fn add_node_info(&mut self, node_info: NodeInfo) {
@@ -138,26 +138,25 @@ impl RosParticipantInner {
     let ros_discovery_topic = domain_participant.create_topic(
       ROSDiscoveryTopic::topic_name().to_string(),
       ROSDiscoveryTopic::type_name().to_string(),
-      &ROSDiscoveryTopic::get_qos(),
+      &ROSDiscoveryTopic::qos(),
       TopicKind::NoKey,
     )?;
 
-    let ros_discovery_publisher =
-      domain_participant.create_publisher(&ROSDiscoveryTopic::get_qos())?;
+    let ros_discovery_publisher = domain_participant.create_publisher(&ROSDiscoveryTopic::qos())?;
     let ros_discovery_subscriber =
-      domain_participant.create_subscriber(&ROSDiscoveryTopic::get_qos())?;
+      domain_participant.create_subscriber(&ROSDiscoveryTopic::qos())?;
 
     let ros_parameter_events_topic = domain_participant.create_topic(
       ParameterEventsTopic::topic_name().to_string(),
       ParameterEventsTopic::type_name().to_string(),
-      &ParameterEventsTopic::get_qos(),
+      &ParameterEventsTopic::qos(),
       TopicKind::NoKey,
     )?;
 
     let ros_rosout_topic = domain_participant.create_topic(
       RosOutTopic::topic_name().to_string(),
       RosOutTopic::type_name().to_string(),
-      &RosOutTopic::get_qos(),
+      &RosOutTopic::qos(),
       TopicKind::NoKey,
     )?;
 
@@ -185,15 +184,15 @@ impl RosParticipantInner {
   /// Gets our current participant info we have sent to ROS2 network
   pub fn get_ros_participant_info(&self) -> ROSParticipantInfo {
     ROSParticipantInfo::new(
-      Gid::from_guid(self.domain_participant.get_guid()),
+      Gid::from_guid(self.domain_participant.guid()),
       self.nodes.iter().map(|(_, p)| p.clone()).collect(),
     )
   }
 
   // Adds new NodeInfo and updates our RosParticipantInfo to ROS2 network
   fn add_node_info(&mut self, mut node_info: NodeInfo) {
-    node_info.add_reader(Gid::from_guid(self.node_reader.get_guid()));
-    node_info.add_writer(Gid::from_guid(self.node_writer.get_guid()));
+    node_info.add_reader(Gid::from_guid(self.node_reader.guid()));
+    node_info.add_writer(Gid::from_guid(self.node_writer.guid()));
 
     self.nodes.insert(node_info.get_full_name(), node_info);
     self.broadcast_node_infos();
@@ -364,9 +363,9 @@ impl RosNode {
   fn generate_node_info(&self) -> NodeInfo {
     let mut node_info = NodeInfo::new(self.name.to_owned(), self.namespace.to_owned());
 
-    node_info.add_writer(Gid::from_guid(self.parameter_events_writer.get_guid()));
+    node_info.add_writer(Gid::from_guid(self.parameter_events_writer.guid()));
     if let Some(row) = &self.rosout_writer {
-      node_info.add_writer(Gid::from_guid(row.get_guid()))
+      node_info.add_writer(Gid::from_guid(row.guid()))
     }
 
     for reader in self.readers.iter() {
@@ -417,11 +416,11 @@ impl RosNode {
       .add_node_info(self.generate_node_info());
   }
 
-  pub fn get_name(&self) -> &str {
+  pub fn name(&self) -> &str {
     &self.name
   }
 
-  pub fn get_namespace(&self) -> &str {
+  pub fn namespace(&self) -> &str {
     &self.namespace
   }
 
@@ -512,7 +511,7 @@ impl RosNode {
       .ros_participant
       .get_ros_discovery_subscriber()
       .create_datareader_no_key::<D, DA>(topic, qos)?;
-    self.add_reader(sub.get_guid());
+    self.add_reader(sub.guid());
     Ok(sub)
   }
 
@@ -537,7 +536,7 @@ impl RosNode {
       .ros_participant
       .get_ros_discovery_subscriber()
       .create_datareader::<D, DA>(topic, qos)?;
-    self.add_reader(sub.get_guid());
+    self.add_reader(sub.guid());
     Ok(sub)
   }
 
@@ -558,7 +557,7 @@ impl RosNode {
       .ros_participant
       .get_ros_discovery_publisher()
       .create_datawriter_no_key(topic, qos)?;
-    self.add_writer(p.get_guid());
+    self.add_writer(p.guid());
     Ok(p)
   }
 
@@ -583,7 +582,7 @@ impl RosNode {
       .ros_participant
       .get_ros_discovery_publisher()
       .create_datawriter(topic, qos)?;
-    self.add_writer(p.get_guid());
+    self.add_writer(p.guid());
     Ok(p)
   }
 }

--- a/src/serialization/message.rs
+++ b/src/serialization/message.rs
@@ -441,7 +441,7 @@ impl MessageBuilder {
         let gap_list = SequenceNumberSet::from_base_and_set(base, &irrelevant_sns);
         let gap = Gap {
           reader_id: reader_guid.entity_id,
-          writer_id: writer.get_entity_id(),
+          writer_id: writer.entity_id(),
           gap_start: base,
           gap_list,
         };
@@ -467,7 +467,7 @@ impl MessageBuilder {
 
     let heartbeat = Heartbeat {
       reader_id: reader_entityid,
-      writer_id: writer.get_entity_id(),
+      writer_id: writer.entity_id(),
       first_sn: first,
       last_sn: last,
       count: writer.heartbeat_message_counter,

--- a/src/structure/entity.rs
+++ b/src/structure/entity.rs
@@ -7,12 +7,12 @@ use crate::structure::guid::{EntityId, GuidPrefix, GUID};
 /// (for usage, DomainParticipant, DataReader and DataWriter implement this)
 /// RTPS 2.3 specification section 8.2.4
 pub trait RTPSEntity {
-  fn get_guid(&self) -> GUID;
+  fn guid(&self) -> GUID;
 
-  fn get_entity_id(&self) -> EntityId {
-    self.get_guid().entity_id
+  fn entity_id(&self) -> EntityId {
+    self.guid().entity_id
   }
-  fn get_guid_prefix(&self) -> GuidPrefix {
-    self.get_guid().guid_prefix
+  fn guid_prefix(&self) -> GuidPrefix {
+    self.guid().guid_prefix
   }
 }

--- a/src/test/random_data.rs
+++ b/src/test/random_data.rs
@@ -30,7 +30,7 @@ pub struct RandomData {
 
 impl Keyed for RandomData {
   type K = i64;
-  fn get_key(&self) -> i64 {
+  fn key(&self) -> i64 {
     self.a
   }
 }

--- a/src/test/shape_type.rs
+++ b/src/test/shape_type.rs
@@ -9,7 +9,7 @@ pub struct ShapeType {
 
 impl Keyed for ShapeType {
   type K = i32;
-  fn get_key(&self) -> Self::K {
+  fn key(&self) -> Self::K {
     self.a
   }
 }


### PR DESCRIPTION
it's not idiomatic to use a `get_` prefix on getters in Rust. This PR removes most of them

see this reference - https://github.com/rust-lang/rfcs/blob/master/text/0344-conventions-galore.md#gettersetter-apis