### PR TITLE
remove std::prelude imports

### DIFF
--- a/src/dds/fragment_assembler.rs
+++ b/src/dds/fragment_assembler.rs
@@ -1,9 +1,5 @@
 //use crate::structure::guid::{GUID, /*EntityId, GuidPrefix*/ };
-use std::{
-  collections::BTreeMap,
-  convert::{From, TryInto},
-  fmt,
-};
+use std::{collections::BTreeMap, convert::TryInto, fmt};
 
 use bit_vec::BitVec;
 use enumflags2::BitFlags;

--- a/src/dds/helpers.rs
+++ b/src/dds/helpers.rs
@@ -1,4 +1,4 @@
-use std::{convert::From, thread};
+use std::thread;
 
 use mio_extras::channel::{SyncSender, TrySendError};
 

--- a/src/dds/with_key/datareader.rs
+++ b/src/dds/with_key/datareader.rs
@@ -1,7 +1,6 @@
 use std::{
   cmp::max,
   collections::BTreeMap,
-  convert::From,
   io,
   marker::PhantomData,
   sync::{Arc, RwLock},

--- a/src/structure/duration.rs
+++ b/src/structure/duration.rs
@@ -1,7 +1,4 @@
-use std::{
-  convert::{From, TryFrom},
-  ops::Div,
-};
+use std::{convert::TryFrom, ops::Div};
 
 use speedy::{Readable, Writable};
 use serde::{Deserialize, Serialize};

--- a/src/structure/locator.rs
+++ b/src/structure/locator.rs
@@ -1,5 +1,5 @@
 use std::{
-  convert::{From, TryInto},
+  convert::TryInto,
   net::{SocketAddrV4, SocketAddrV6},
 };
 pub use std::net::{IpAddr, Ipv4Addr, Ipv6Addr, SocketAddr};

--- a/src/structure/sequence_number.rs
+++ b/src/structure/sequence_number.rs
@@ -1,6 +1,5 @@
 use std::{
   cmp::{min, Ord, PartialOrd},
-  convert::From,
   fmt::Debug,
   hash::Hash,
   mem::size_of,

--- a/src/structure/sequence_number.rs
+++ b/src/structure/sequence_number.rs
@@ -1,5 +1,5 @@
 use std::{
-  cmp::{min, Ord, PartialOrd},
+  cmp::min,
   fmt::Debug,
   hash::Hash,
   mem::size_of,


### PR DESCRIPTION
Some of the imported traits are in the standard prelude, and can be removed