### PR TITLE
fix or silence pedantic lints

### DIFF
--- a/src/dds/message_receiver.rs
+++ b/src/dds/message_receiver.rs
@@ -28,7 +28,7 @@ use crate::structure::sequence_number::SequenceNumber;
 
 const RTPS_MESSAGE_HEADER_SIZE: usize = 20;
 
-/// MessageReceiver is the submessage sequence interpreter described in
+/// [`MessageReceiver`] is the submessage sequence interpreter described in
 /// RTPS spec v2.3 Section 8.3.4 "The RTPS Message Receiver".
 /// It calls the message/submessage deserializers to parse the sequence of
 /// submessages. Then it processes the instructions in the Interpreter
@@ -371,10 +371,10 @@ impl MessageReceiver {
         }
       }
       InterpreterSubmessage::InfoDestination(info_dest, _flags) => {
-        if info_dest.guid_prefix != GUID::GUID_UNKNOWN.guid_prefix {
-          self.dest_guid_prefix = info_dest.guid_prefix;
-        } else {
+        if info_dest.guid_prefix == GUID::GUID_UNKNOWN.guid_prefix {
           self.dest_guid_prefix = self.own_guid_prefix;
+        } else {
+          self.dest_guid_prefix = info_dest.guid_prefix;
         }
       }
     }
@@ -385,7 +385,7 @@ impl MessageReceiver {
       self
         .available_readers
         .get(&eid)
-        .map(|r| r.notify_cache_change());
+        .map(Reader::notify_cache_change);
     }
   }
 

--- a/src/dds/with_key/datareader.rs
+++ b/src/dds/with_key/datareader.rs
@@ -1599,7 +1599,7 @@ mod tests {
         representation_options: [0, 0],
         value: Bytes::from(to_bytes::<RandomData, LittleEndian>(&data_key1).unwrap()),
       }),
-      ..Default::default()
+      ..Data::default()
     };
     let data_msg2 = Data {
       reader_id: reader.entity_id(),
@@ -1610,7 +1610,7 @@ mod tests {
         representation_options: [0, 0],
         value: Bytes::from(to_bytes::<RandomData, LittleEndian>(&data_key2_1).unwrap()),
       }),
-      ..Default::default()
+      ..Data::default()
     };
     let data_msg3 = Data {
       reader_id: reader.entity_id(),
@@ -1621,7 +1621,7 @@ mod tests {
         representation_options: [0, 0],
         value: Bytes::from(to_bytes::<RandomData, LittleEndian>(&data_key2_2).unwrap()),
       }),
-      ..Default::default()
+      ..Data::default()
     };
     let data_msg4 = Data {
       reader_id: reader.entity_id(),
@@ -1632,7 +1632,7 @@ mod tests {
         representation_options: [0, 0],
         value: Bytes::from(to_bytes::<RandomData, LittleEndian>(&data_key2_3).unwrap()),
       }),
-      ..Default::default()
+      ..Data::default()
     };
     reader.handle_data_msg(data_msg, data_flags, &mr_state);
     reader.handle_data_msg(data_msg2, data_flags, &mr_state);

--- a/src/discovery/data_types/spdp_participant_data.rs
+++ b/src/discovery/data_types/spdp_participant_data.rs
@@ -105,12 +105,12 @@ impl SpdpDiscoveredParticipantData {
       EntityId::UNKNOWN,
     );
 
-    if !is_metatraffic {
-      // TODO: possible multicast addresses
-      proxy.unicast_locator_list = self.default_unicast_locators.clone();
-    } else {
+    if is_metatraffic {
       // TODO: possible multicast addresses
       proxy.unicast_locator_list = self.metatraffic_unicast_locators.clone();
+    } else {
+      // TODO: possible multicast addresses
+      proxy.unicast_locator_list = self.default_unicast_locators.clone();
     }
 
     proxy

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -20,9 +20,8 @@
   clippy::option_map_unit_fn,
   // option_map_unit_fn suggests changing option.map( ) with () return value to if let -construct,
   // but that may break code flow.
-  dead_code
+  dead_code,
 )]
-#![warn(clippy::pedantic)]
 
 #[macro_use]
 mod serialization_test;

--- a/src/serialization/builtin_data_deserializer.rs
+++ b/src/serialization/builtin_data_deserializer.rs
@@ -765,10 +765,6 @@ impl BuiltinDataDeserializer {
       return Some(0);
     }
 
-    let parameter_length_value = CDRDeserializerAdapter::from_bytes(&buffer[2..4], rep);
-    match parameter_length_value {
-      Ok(val) => Some(val),
-      _ => None,
-    }
+    CDRDeserializerAdapter::from_bytes(&buffer[2..4], rep).ok()
   }
 }

--- a/src/structure/guid.rs
+++ b/src/structure/guid.rs
@@ -29,7 +29,7 @@ impl GuidPrefix {
       if ix >= 12 {
         break;
       }
-      pr[ix] = *data
+      pr[ix] = *data;
     }
     GuidPrefix { entity_key: pr }
   }
@@ -89,7 +89,7 @@ impl<C: Context> Writable<C> for GuidPrefix {
   #[inline]
   fn write_to<T: ?Sized + Writer<C>>(&self, writer: &mut T) -> Result<(), C::Error> {
     for elem in &self.entity_key {
-      writer.write_u8(*elem)?
+      writer.write_u8(*elem)?;
     }
     Ok(())
   }


### PR DESCRIPTION
in an earlier PR i added `clippy::pedantic` lint warnings. This is *very* noisy in this code-base. This PR addresses a couple of those lints, and silences the rest.