### PR TITLE
dev-dependencies clean up

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -40,14 +40,17 @@ local-ip-address = "0.4.4"
 [dev-dependencies]
 serde_repr = {version = "0.1" }
 log = "0.4"
-# shapes-demo:
-ctrlc = "3.1.6"     
-termion = "1.5.5"
-env_logger = "0.9.0"
-clap = "2.33"
-# turle_teleop
 log4rs = "1"
 test-case = "1.2.0"
+
 # ros_visualizer
 crossterm = "0.22"
 tui = { version = "0.16", default-features = false, features = ['crossterm'] }
+
+# shapes-demo
+clap = "2.33"
+ctrlc = "3.1.6"
+
+[target.'cfg(unix)'.dev-dependencies]
+# turle_teleop
+termion = "1.5.5"

--- a/examples/turtle_teleop/main.rs
+++ b/examples/turtle_teleop/main.rs
@@ -1,7 +1,11 @@
 #![deny(clippy::all)]
 
+#[cfg(not(unix))]
+fn main() { println!("This example only works on a unix based system"); }
+
 use std::time::Duration;
 
+#[cfg(unix)]
 use termion::raw::*;
 #[allow(unused_imports)]
 use log::{debug, error, info, warn};
@@ -13,9 +17,11 @@ use rustdds::{
   ros2::{NodeOptions, RosParticipant},
   *,
 };
+#[cfg(unix)]
 use ui::{RosCommand, UiController};
 
 // modules
+#[cfg(unix)]
 mod ui;
 
 const TURTLE_CMD_VEL_READER_TOKEN: Token = Token(1);
@@ -60,6 +66,7 @@ impl Vector3 {
   };
 }
 
+#[cfg(unix)]
 fn main() {
   // Here is a fixed path, so this example must be started from
   // RustDDS main directory
@@ -99,6 +106,7 @@ fn main() {
   std::thread::sleep(Duration::from_millis(10));
 }
 
+#[cfg(unix)]
 fn ros2_loop(
   command_receiver: mio_channel::Receiver<RosCommand>,
   readback_sender: mio_channel::SyncSender<Twist>,

--- a/examples/turtle_teleop/ui.rs
+++ b/examples/turtle_teleop/ui.rs
@@ -1,3 +1,5 @@
+#![cfg(unix)]
+
 use std::{io::Write, os::unix::io::AsRawFd};
 
 #[allow(unused_imports)]


### PR DESCRIPTION
- Organized `dev-dependencies`
- Removed unused dev dependencies
- Added some compilation conditionals to the turtle_teleop example to enable running `cargo test` on Windows
