### PR TITLE
Discovery rework

### DIFF
--- a/src/dds/dp_event_loop.rs
+++ b/src/dds/dp_event_loop.rs
@@ -774,9 +774,12 @@ mod tests {
     let (spdp_liveness_sender, _spdp_liveness_receiver) = mio_channel::sync_channel(8);
 
     let ddshc = Arc::new(RwLock::new(DDSCache::new()));
+    let (discovery_db_event_sender, _discovery_db_event_receiver) =
+      mio_channel::sync_channel::<()>(4);
+
     let discovery_db = Arc::new(RwLock::new(DiscoveryDB::new(
       GUID::new_participant_guid(),
-      None,
+      discovery_db_event_sender,
     )));
 
     let domain_info = DomainInfo {

--- a/src/dds/dp_event_loop.rs
+++ b/src/dds/dp_event_loop.rs
@@ -716,24 +716,18 @@ impl DPEventLoop {
     match self.ddscache.write() {
       Ok(mut ddsc) => {
         let ptd = &dwd.publication_topic_data;
-        ddsc.add_new_topic(
-          ptd.topic_name.clone(),
-          TypeDesc::new(ptd.type_name.clone())
-        );
+        ddsc.add_new_topic(ptd.topic_name.clone(), TypeDesc::new(ptd.type_name.clone()));
       }
-      
+
       _ => panic!("DDSCache is poisoned"),
     }
   }
-  
 
   fn remote_writer_lost(&mut self, writer_guid: GUID) {
     for reader in self.message_receiver.available_readers.values_mut() {
       reader.remove_writer_proxy(writer_guid);
     }
   }
-
-  
 }
 
 // -----------------------------------------------------------

--- a/src/dds/dp_event_loop.rs
+++ b/src/dds/dp_event_loop.rs
@@ -291,7 +291,6 @@ impl DPEventLoop {
                       ev_wrapper.remote_participant_lost(guid_prefix);
                     }
 
-                    TopicsInfoUpdated => ev_wrapper.update_topics(),
                     AssertTopicLiveliness {
                       writer_guid,
                       manual_assertion,
@@ -704,6 +703,7 @@ impl DPEventLoop {
   }
 
   fn remote_writer_discovered(&mut self, dwd: &DiscoveredWriterData) {
+    // update writer proxies in local readers
     for reader in self.message_receiver.available_readers.values_mut() {
       if &dwd.publication_topic_data.topic_name == reader.topic_name() {
         reader.update_writer_proxy(
@@ -712,7 +712,20 @@ impl DPEventLoop {
         );
       }
     }
+    // notify DDSCache to create topic if it does not exist yet
+    match self.ddscache.write() {
+      Ok(mut ddsc) => {
+        let ptd = &dwd.publication_topic_data;
+        ddsc.add_new_topic(
+          ptd.topic_name.clone(),
+          TypeDesc::new(ptd.type_name.clone())
+        );
+      }
+      
+      _ => panic!("DDSCache is poisoned"),
+    }
   }
+  
 
   fn remote_writer_lost(&mut self, writer_guid: GUID) {
     for reader in self.message_receiver.available_readers.values_mut() {
@@ -720,26 +733,7 @@ impl DPEventLoop {
     }
   }
 
-  fn update_topics(&mut self) {
-    match self.discovery_db.read() {
-      Ok(db) => match self.ddscache.write() {
-        Ok(mut ddsc) => {
-          for topic in db.all_topics() {
-            // How do you know when topic is keyed or not?
-            // A: Apparently the Topic conversation
-            // over Discovery does not know this.
-            // The keyedness is implicit in the data type.
-            ddsc.add_new_topic(
-              topic.topic_data.name.clone(),
-              TypeDesc::new(topic.topic_data.type_name.clone()),
-            );
-          }
-        }
-        _ => panic!("DDSCache is poisoned"),
-      },
-      _ => panic!("DiscoveryDB is poisoned"),
-    }
-  }
+  
 }
 
 // -----------------------------------------------------------

--- a/src/dds/participant.rs
+++ b/src/dds/participant.rs
@@ -724,10 +724,10 @@ impl DomainParticipantInner {
     let dds_cache = Arc::new(RwLock::new(DDSCache::new()));
 
     let (discovery_db_event_sender, discovery_db_event_receiver) =
-      mio_channel::sync_channel::<()>(1);
+      mio_channel::sync_channel::<()>(4);
     let discovery_db = Arc::new(RwLock::new(DiscoveryDB::new(
       new_guid,
-      Some(discovery_db_event_sender),
+      discovery_db_event_sender,
     )));
 
     let (stop_poll_sender, stop_poll_receiver) = mio_channel::channel::<()>();

--- a/src/dds/participant.rs
+++ b/src/dds/participant.rs
@@ -724,7 +724,7 @@ impl DomainParticipantInner {
     let dds_cache = Arc::new(RwLock::new(DDSCache::new()));
 
     let (discovery_db_event_sender, discovery_db_event_receiver) =
-      mio_channel::sync_channel::<()>(4);
+      mio_channel::sync_channel::<()>(1);
     let discovery_db = Arc::new(RwLock::new(DiscoveryDB::new(
       new_guid,
       discovery_db_event_sender,
@@ -971,7 +971,7 @@ impl DomainParticipantInner {
       .read()
       .unwrap_or_else(|e| panic!("DiscoveryDB is poisoned. {:?}", e));
 
-    db.all_topics().cloned().collect()
+    db.all_user_topics().cloned().collect()
   }
 } // impl
 

--- a/src/dds/topic.rs
+++ b/src/dds/topic.rs
@@ -73,7 +73,6 @@ impl Topic {
     self.inner.participant()
   }
 
-  // TODO: Confusing combination of borrows and owns
   fn get_type(&self) -> TypeDesc {
     self.inner.get_type()
   }

--- a/src/discovery/data_types/topic_data.rs
+++ b/src/discovery/data_types/topic_data.rs
@@ -558,9 +558,12 @@ pub struct TopicBuiltinTopicData {
 }
 
 impl TopicBuiltinTopicData {
-  pub fn new(key: Option<GUID>, name: String, type_name:String, qos: &QosPolicies) 
-    -> TopicBuiltinTopicData 
-  {
+  pub fn new(
+    key: Option<GUID>,
+    name: String,
+    type_name: String,
+    qos: &QosPolicies,
+  ) -> TopicBuiltinTopicData {
     TopicBuiltinTopicData {
       key,
       name,
@@ -614,7 +617,10 @@ pub struct DiscoveredTopicData {
 }
 
 impl DiscoveredTopicData {
-  pub fn new(updated_time: DateTime<Utc>, topic_data: TopicBuiltinTopicData) -> DiscoveredTopicData {
+  pub fn new(
+    updated_time: DateTime<Utc>,
+    topic_data: TopicBuiltinTopicData,
+  ) -> DiscoveredTopicData {
     DiscoveredTopicData {
       updated_time,
       topic_data,
@@ -657,7 +663,7 @@ impl PlCdrDeserialize for DiscoveredTopicData {
           e, &input_bytes,
         ))
       })
-      .map(|td| DiscoveredTopicData::new(Utc::now(),td) )
+      .map(|td| DiscoveredTopicData::new(Utc::now(), td))
   }
 }
 

--- a/src/discovery/data_types/topic_data.rs
+++ b/src/discovery/data_types/topic_data.rs
@@ -557,6 +557,29 @@ pub struct TopicBuiltinTopicData {
   pub ownership: Option<Ownership>,
 }
 
+impl TopicBuiltinTopicData {
+  pub fn new(key: Option<GUID>, name: String, type_name:String, qos: &QosPolicies) 
+    -> TopicBuiltinTopicData 
+  {
+    TopicBuiltinTopicData {
+      key,
+      name,
+      type_name,
+      durability: qos.durability(),
+      deadline: qos.deadline(),
+      latency_budget: qos.latency_budget(),
+      liveliness: qos.liveliness(),
+      reliability: qos.reliability(),
+      lifespan: qos.lifespan(),
+      destination_order: qos.destination_order(),
+      presentation: qos.presentation(),
+      history: qos.history(),
+      resource_limits: qos.resource_limits(),
+      ownership: qos.ownership(),
+    }
+  }
+}
+
 impl HasQoSPolicy for TopicBuiltinTopicData {
   fn qos(&self) -> QosPolicies {
     QosPolicies {
@@ -591,9 +614,9 @@ pub struct DiscoveredTopicData {
 }
 
 impl DiscoveredTopicData {
-  pub fn new(topic_data: TopicBuiltinTopicData) -> DiscoveredTopicData {
+  pub fn new(updated_time: DateTime<Utc>, topic_data: TopicBuiltinTopicData) -> DiscoveredTopicData {
     DiscoveredTopicData {
-      updated_time: Utc::now(),
+      updated_time,
       topic_data,
     }
   }
@@ -634,7 +657,7 @@ impl PlCdrDeserialize for DiscoveredTopicData {
           e, &input_bytes,
         ))
       })
-      .map(DiscoveredTopicData::new)
+      .map(|td| DiscoveredTopicData::new(Utc::now(),td) )
   }
 }
 

--- a/src/discovery/data_types/topic_data.rs
+++ b/src/discovery/data_types/topic_data.rs
@@ -893,7 +893,7 @@ mod tests {
   fn td_discovered_topic_data_ser_deser() {
     let topic_data = topic_data().unwrap();
 
-    let dtd = DiscoveredTopicData::new(topic_data);
+    let dtd = DiscoveredTopicData::new(Utc::now(), topic_data);
 
     let sdata = dtd
       .to_pl_cdr_bytes(RepresentationIdentifier::PL_CDR_LE)

--- a/src/discovery/discovery.rs
+++ b/src/discovery/discovery.rs
@@ -1276,7 +1276,7 @@ impl Discovery {
 
   pub fn write_topic_info(&self) {
     let db = self.discovery_db_read();
-    let datas = db.all_user_topics();
+    let datas = db.local_user_topics();
     for data in datas {
       if let Err(e) = self.dcps_topic_writer.write(data.clone(), None) {
         error!("Unable to write new topic info: {:?}", e);

--- a/src/discovery/discovery.rs
+++ b/src/discovery/discovery.rs
@@ -1385,6 +1385,7 @@ impl Discovery {
 
 #[cfg(test)]
 mod tests {
+  use chrono::Utc;
   use std::net::SocketAddr;
 
   use bytes::Bytes;
@@ -1619,7 +1620,7 @@ mod tests {
   fn discovery_topic_data_test() {
     let _participant = DomainParticipant::new(0);
 
-    let topic_data = DiscoveredTopicData::new(TopicBuiltinTopicData {
+    let topic_data = DiscoveredTopicData::new(Utc::now(), TopicBuiltinTopicData {
       key: None,
       name: String::from("Square"),
       type_name: String::from("ShapeType"),

--- a/src/discovery/discovery_db.rs
+++ b/src/discovery/discovery_db.rs
@@ -467,6 +467,16 @@ impl DiscoveryDB {
       .flatten()
   }
 
+  // as above, but only from my GUID
+  pub fn local_user_topics(&self) -> impl Iterator<Item = &DiscoveredTopicData> {
+    let me = self.my_guid.prefix;
+    self.topics
+      .iter()
+      .filter(|(s, _)| !s.starts_with("DCPS"))
+      .map(move |(_, gm)| gm.iter().filter(move |(guid,_)| **guid == me ).map(|(_,dtd)| dtd) )
+      .flatten()
+  }
+
   // a Topic may have multiple definitions, because there may be multiple
   // participants publishing the topic information.
   // At least the QoS details may be different.

--- a/src/discovery/discovery_db.rs
+++ b/src/discovery/discovery_db.rs
@@ -404,8 +404,10 @@ impl DiscoveryDB {
 
     if notify {
       self.topic_updated_sender.try_send(())
+        // It is quite normal for this to fail due to channel full,
+        // because usually there is no-one at the other end receiving.
         .unwrap_or_else( |e| 
-          warn!("update_topic_data: Notification send failed: {:?}",e));      
+          trace!("update_topic_data: Notification send failed: {:?}",e));      
     }
   }
 

--- a/src/discovery/discovery_db.rs
+++ b/src/discovery/discovery_db.rs
@@ -1,5 +1,5 @@
 use std::{
-  collections::{BTreeMap, HashMap},
+  collections::BTreeMap,
   time::Instant,
 };
 use chrono::Utc;
@@ -38,17 +38,18 @@ const PARTICIPANT_LEASE_DURATION_TOLREANCE: Duration = Duration::from_secs(0);
 pub(crate) struct DiscoveryDB {
   my_guid: GUID,
   participant_proxies: BTreeMap<GuidPrefix, SpdpDiscoveredParticipantData>,
-  participant_last_life_signs: HashMap<GuidPrefix, Instant>,
+  participant_last_life_signs: BTreeMap<GuidPrefix, Instant>,
+  
   // local writer proxies for topics (topic name acts as key)
-  local_topic_writers: HashMap<GUID, DiscoveredWriterData>,
+  local_topic_writers: BTreeMap<GUID, DiscoveredWriterData>,
   // local reader proxies for topics (topic name acts as key)
-  local_topic_readers: HashMap<GUID, DiscoveredReaderData>,
+  local_topic_readers: BTreeMap<GUID, DiscoveredReaderData>,
 
   // remote readers and writers (via discovery)
   external_topic_readers: BTreeMap<GUID, DiscoveredReaderData>,
   external_topic_writers: BTreeMap<GUID, DiscoveredWriterData>,
 
-  topics: HashMap<String, DiscoveredTopicData>,
+  topics: BTreeMap<String, DiscoveredTopicData>,
 
   topic_updated_sender: mio_extras::channel::SyncSender<()>,
 }
@@ -61,12 +62,12 @@ impl DiscoveryDB {
     DiscoveryDB {
       my_guid,
       participant_proxies: BTreeMap::new(),
-      participant_last_life_signs: HashMap::new(),
-      local_topic_writers: HashMap::new(),
-      local_topic_readers: HashMap::new(),
+      participant_last_life_signs: BTreeMap::new(),
+      local_topic_writers: BTreeMap::new(),
+      local_topic_readers: BTreeMap::new(),
       external_topic_readers: BTreeMap::new(),
       external_topic_writers: BTreeMap::new(),
-      topics: HashMap::new(),
+      topics: BTreeMap::new(),
       topic_updated_sender,
     }
   }

--- a/src/discovery/discovery_db.rs
+++ b/src/discovery/discovery_db.rs
@@ -2,6 +2,7 @@ use std::{
   collections::{BTreeMap, HashMap},
   time::Instant,
 };
+use chrono::Utc;
 
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
@@ -351,65 +352,40 @@ impl DiscoveryDB {
   }
 
   pub fn update_topic_data_drd(&mut self, drd: &DiscoveredReaderData) {
-    let topic_data = DiscoveredTopicData::new(TopicBuiltinTopicData {
-      key: None,
-      name: drd.subscription_topic_data.topic_name().clone(),
-      type_name: drd.subscription_topic_data.type_name().clone(),
-      durability: *drd.subscription_topic_data.durability(),
-      deadline: *drd.subscription_topic_data.deadline(),
-      latency_budget: *drd.subscription_topic_data.latency_budget(),
-      liveliness: *drd.subscription_topic_data.liveliness(),
-      reliability: *drd.subscription_topic_data.reliability(),
-      lifespan: *drd.subscription_topic_data.lifespan(),
-      destination_order: *drd.subscription_topic_data.destination_order(),
-      presentation: *drd.subscription_topic_data.presentation(),
-      history: None,
-      resource_limits: None,
-      ownership: *drd.subscription_topic_data.ownership(),
-    });
+    let topic_data = DiscoveredTopicData::new(
+      Utc::now(),
+      TopicBuiltinTopicData::new(
+        None,
+        drd.subscription_topic_data.topic_name().clone(),
+        drd.subscription_topic_data.type_name().clone(),
+        &drd.subscription_topic_data.generate_qos(),
+      ));
 
     self.update_topic_data(&topic_data);
   }
 
   pub fn update_topic_data_dwd(&mut self, dwd: &DiscoveredWriterData) {
-    let topic_data = DiscoveredTopicData::new(TopicBuiltinTopicData {
-      key: None,
-      name: dwd.publication_topic_data.topic_name.clone(),
-      type_name: dwd.publication_topic_data.type_name.clone(),
-      durability: dwd.publication_topic_data.durability,
-      deadline: dwd.publication_topic_data.deadline,
-      latency_budget: dwd.publication_topic_data.latency_budget,
-      liveliness: dwd.publication_topic_data.liveliness,
-      reliability: dwd.publication_topic_data.reliability,
-      lifespan: dwd.publication_topic_data.lifespan,
-      destination_order: dwd.publication_topic_data.destination_order,
-      presentation: dwd.publication_topic_data.presentation,
-      history: None,
-      resource_limits: None,
-      ownership: dwd.publication_topic_data.ownership,
-    });
+    let topic_data = DiscoveredTopicData::new(
+      Utc::now(), 
+      TopicBuiltinTopicData::new(
+        None,
+        dwd.publication_topic_data.topic_name.clone(),
+        dwd.publication_topic_data.type_name.clone(),
+        &dwd.publication_topic_data.qos(),
+      ));
 
     self.update_topic_data(&topic_data);
   }
 
   pub fn update_topic_data_p(&mut self, topic: &Topic) {
-    let topic_data = DiscoveredTopicData::new(TopicBuiltinTopicData {
-      key: None,
-      name: topic.name(),
-      type_name: String::from(topic.get_type().name()),
-      durability: topic.qos().durability,
-      deadline: topic.qos().deadline,
-      latency_budget: topic.qos().latency_budget,
-      liveliness: topic.qos().liveliness,
-      reliability: topic.qos().reliability,
-      lifespan: topic.qos().lifespan,
-      destination_order: topic.qos().destination_order,
-      presentation: topic.qos().presentation,
-      history: topic.qos().history,
-      resource_limits: topic.qos().resource_limits,
-      ownership: topic.qos().ownership,
-    });
-
+    let topic_data = DiscoveredTopicData::new(
+      Utc::now(), 
+      TopicBuiltinTopicData::new(
+        None,
+        topic.name(),
+        topic.get_type().name().to_owned(),
+        &topic.qos(),
+      ));
     self.update_topic_data(&topic_data);
   }
 

--- a/src/network/constant.rs
+++ b/src/network/constant.rs
@@ -111,7 +111,6 @@ pub(crate) enum DiscoveryNotificationType {
   ParticipantLost {
     guid_prefix: GuidPrefix,
   },
-  TopicsInfoUpdated,
   AssertTopicLiveliness {
     writer_guid: GUID,
     manual_assertion: bool,

--- a/src/structure/dds_cache.rs
+++ b/src/structure/dds_cache.rs
@@ -38,9 +38,10 @@ impl DDSCache {
   // Insert new topic if it does not exist.
   // If it exists already, do nothing.
   pub fn add_new_topic(&mut self, topic_name: String, topic_data_type: TypeDesc) {
-    self.topic_caches
+    self
+      .topic_caches
       .entry(topic_name.clone())
-      .or_insert_with(|| TopicCache::new(topic_name, topic_data_type) );
+      .or_insert_with(|| TopicCache::new(topic_name, topic_data_type));
   }
 
   // TODO: Investigate why this is not used.

--- a/src/structure/dds_cache.rs
+++ b/src/structure/dds_cache.rs
@@ -35,11 +35,12 @@ impl DDSCache {
     }
   }
 
+  // Insert new topic if it does not exist.
+  // If it exists already, do nothing.
   pub fn add_new_topic(&mut self, topic_name: String, topic_data_type: TypeDesc) {
-    self.topic_caches.insert(
-      topic_name.clone(),
-      TopicCache::new(topic_name, topic_data_type),
-    );
+    self.topic_caches
+      .entry(topic_name.clone())
+      .or_insert_with(|| TopicCache::new(topic_name, topic_data_type) );
   }
 
   // TODO: Investigate why this is not used.


### PR DESCRIPTION
Several Discovery changes:
* If several participants are announcing the same topic, track them separately.
* Only announce self-defined topics, do not repeat what we learn from others.
* Some simplifications and cleanups.