### PR TITLE
Partial fix for fragment assembly

### DIFF
--- a/src/dds/fragment_assembler.rs
+++ b/src/dds/fragment_assembler.rs
@@ -58,9 +58,10 @@ impl AssemblyBuffer {
     let payload_header = 4; // RepresentationIdentifier + RepresentationOptions
     let frag_size = usize::from(frag_size) - payload_header;
     let frags_in_subm = usize::from(datafrag.fragments_in_submessage);
-    let start_frag_from_0: usize = u32::from(datafrag.fragment_starting_num)
+    let fragment_starting_num: usize = u32::from(datafrag.fragment_starting_num)
       .try_into()
       .unwrap();
+    let start_frag_from_0 = fragment_starting_num - 1;
 
     debug!(
       "insert_frags: datafrag.writer_sn = {:?}, frag_size = {:?}, datafrag.fragment_size = {:?}, datafrag.fragment_starting_num = {:?}, \
@@ -86,8 +87,8 @@ impl AssemblyBuffer {
     self.buffer_bytes.as_mut()[from_byte..to_before_byte]
       .copy_from_slice(&datafrag.serialized_payload.value);
 
-    for f in start_frag_from_0..frags_in_subm {
-      self.received_bitmap.set(f, true);
+    for f in 0..frags_in_subm {
+      self.received_bitmap.set(start_frag_from_0 + f, true);
     }
     self.modified_time = Timestamp::now();
   }

--- a/src/dds/fragment_assembler.rs
+++ b/src/dds/fragment_assembler.rs
@@ -138,6 +138,7 @@ impl FragmentAssembler {
     abuf.insert_frags(datafrag, frag_size);
 
     if abuf.is_complete() {
+      debug!("new_datafrag: COMPLETED FRAGMENT");
       if let Some(abuf) = self.assembly_buffers.remove(&writer_sn) {
         // Return what we have assembled.
         let ser_data_or_key = SerializedPayload::new(rep_id, abuf.buffer_bytes.to_vec());
@@ -153,6 +154,7 @@ impl FragmentAssembler {
         None
       }
     } else {
+      debug!("new_dataFrag: FRAGMENT NOT COMPLETED YET");
       None
     }
   }

--- a/src/dds/fragment_assembler.rs
+++ b/src/dds/fragment_assembler.rs
@@ -71,9 +71,15 @@ impl AssemblyBuffer {
     );
 
     // unwrap: u32 should fit into usize
-    let from_byte = (start_frag_from_0 - 1) * frag_size;
-    let to_before_byte: usize = from_byte + (frags_in_subm * frag_size);
-    
+    let from_byte = start_frag_from_0 * frag_size;
+    // Last fragment might be smaller than fragment size
+    let to_before_byte = if fragment_starting_num < self.fragment_count {
+      from_byte + (frags_in_subm * frag_size)
+    } else {
+      from_byte + datafrag.serialized_payload.value.len()
+    };
+
+
     debug!(
       "insert_frags: from_byte = {:?}, to_before_byte = {:?}",
       from_byte, to_before_byte


### PR DESCRIPTION
* Add debug prints
* Use correct frag size for SerializedPayload
* received_bitmap tracks received fragments instead of bytes