### PR TITLE
Add zero check for string bytes

### DIFF
--- a/src/dds/reader.rs
+++ b/src/dds/reader.rs
@@ -578,9 +578,9 @@ impl Reader {
         // This is normal if the DATA was broadcast, but it was from another topic.
         // We just ignore the data in such a case
         // ... unless it is Discovery traffic.
-        if writer_guid.entity_id.entity_kind.is_user_defined() {
-          return;
-        }
+        // if writer_guid.entity_id.entity_kind.is_user_defined() {
+        //   return;
+        // }
       }
     } else {
       // stateless reader

--- a/src/serialization/cdr_deserializer.rs
+++ b/src/serialization/cdr_deserializer.rs
@@ -261,6 +261,7 @@ where
     This is a hacky "Fix" for IntercomDDS version 01.05 protocol version 2.1.
     Where IntercomDDS sends an empty string with no NULL terminator.
     */
+    let bytes_without_null;
     if bytes.len().is_zero() {
       bytes_without_null = bytes;
     } else {


### PR DESCRIPTION
Add a fix for IntercomDDS sending an empty string with no null terminator in some cases. 
Without this fix, an empty string will cause a panic