### PR TITLE
Avoid WouldBlock error when on Windows

### DIFF
--- a/src/network/udp_sender.rs
+++ b/src/network/udp_sender.rs
@@ -7,7 +7,7 @@ use std::net::Ipv4Addr;
 
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
-use mio::net::UdpSocket;
+use std::net::UdpSocket;
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 #[cfg(windows)]
 use local_ip_address::list_afinet_netifas;
@@ -48,7 +48,7 @@ impl UDPSender {
             )
           });
       }
-      UdpSocket::from_socket(std::net::UdpSocket::from(raw_socket))?
+      std::net::UdpSocket::from(raw_socket)
     };
 
     // We set multicasting loop on so that we can hear other DomainParticipant
@@ -82,7 +82,7 @@ impl UDPSender {
       mc_socket.set_multicast_loop_v4(true).unwrap_or_else(|e| {
         error!("Cannot set multicast loop on: {:?}", e);
       });
-      multicast_sockets.push(UdpSocket::from_socket(mc_socket)?);
+      multicast_sockets.push(mc_socket);
     } // end for
 
     let sender = Self {


### PR DESCRIPTION
Fixes #249

1) Tried to set `.set_nonblocking(false)` on `mio` socket, but this option seemed to not exist.
2) Changed out the `mio` based socket for the `std`, which seemed to resolve the problem.

If I had to guess I think `mio` is setting `.set_nonblocking(true)` for some reason in its socket implementation.