### PR TITLE
Implement BuiltinCryptoToken and associated types

### DIFF
--- a/src/security/cryptographic/builtin_types.rs
+++ b/src/security/cryptographic/builtin_types.rs
@@ -43,8 +43,8 @@ impl TryFrom<CryptoToken> for BuiltinCryptoToken {
 
       (cid,_,_)  => 
         Err(Self::Error 
-          { msg: format!("CryptoToken has wrong class_id. Expected {}",
-                CRYPTO_TOKEN_CLASS_ID ) 
+          { msg: format!("CryptoToken has wrong class_id. Expected {}, got {}",
+                CRYPTO_TOKEN_CLASS_ID , cid) 
           } ),
 
     }


### PR DESCRIPTION
Also implements From and TryFrom traits to convert between general and plugin-specific types. The idea is that outside the plugin only the general ones are used, which contain serialized data, and they are converted to more useful types inside the plugin, which knows the correct deserialization etc.

Please check if this makes sense and cdr (de)serializer etc. are used correctly