### PR TITLE
Attempt at restoring Windows compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,7 +17,7 @@ rust-version = "1.66.1"
 mio_06 = { package = "mio" , version ="^0.6.23" } 
 mio-extras = "2.0.6"
 
-mio_08 = { package = "mio" , version ="0.8.5", features = ["net"] } 
+mio_08 = { package = "mio" , version ="0.8.5", features = ["net", "os-poll"] } 
 socketpair = "0.19"
 
 bit-vec = "0.6.2"
@@ -40,6 +40,8 @@ static_assertions = "1.1"
 thiserror = "1.0.29"
 cdr-encoding-size = { version="^0.5" }
 futures = "0.3"
+io-extras = "0.18.0"
+smol = "1.3"
 
 [target.'cfg(windows)'.dependencies]
 local-ip-address = "0.5.3"

--- a/src/mio_source.rs
+++ b/src/mio_source.rs
@@ -1,12 +1,21 @@
 use std::{
   io,
   io::{Read, Write},
-  os::fd::{AsRawFd, FromRawFd, OwnedFd},
   sync::Mutex,
 };
 
+#[cfg(not(target_os = "windows"))]
+use std::os::fd::{AsRawFd, FromRawFd, OwnedFd};
+#[cfg(target_os = "windows")]
+use mio_08::net::{TcpListener, TcpStream};
+#[cfg(target_os = "windows")]
+use std::{thread::sleep, time::Duration};
+
+
 #[allow(unused_imports)]
 use log::{debug, error, info, trace, warn};
+
+#[cfg(not(target_os = "windows"))]
 use socketpair::*;
 use mio_08::{self, *};
 
@@ -16,43 +25,52 @@ use mio_08::{self, *};
 // These Events carry no data.
 
 // This is the event receiver end. It is a "Source" in the terminology of mio.
+#[cfg(target_os = "windows")]
+pub struct PollEventSource {
+  rec_mio_socket: Mutex<mio_08::net::TcpStream>,
+}
+
+#[cfg(not(target_os = "windows"))]
 pub struct PollEventSource {
   #[allow(dead_code)]
   rec_sps: SocketpairStream, // we are storing this just to keep the socket alive
   rec_mio_socket: Mutex<mio_08::net::TcpStream>,
 }
 
+
 // TODO: How to store the socket so that it is correctly tracked and dropped
 // when these PolEventSource /-Sender are dropped. Can we do that without
 // unsafe?
 
+#[cfg(target_os = "windows")]
+pub struct PollEventSender {
+  send_mio_socket: Mutex<mio_08::net::TcpStream>,
+}
+
+#[cfg(not(target_os = "windows"))]
 pub struct PollEventSender {
   #[allow(dead_code)]
   send_sps: SocketpairStream,
   send_mio_socket: Mutex<mio_08::net::TcpStream>,
 }
 
+#[cfg(not(target_os = "windows"))]
 fn set_non_blocking(s: SocketpairStream) -> io::Result<SocketpairStream> {
   let owned_fd = OwnedFd::from(s);
   let std_socket = std::net::TcpStream::from(owned_fd);
   std_socket.set_nonblocking(true)?;
+
   Ok(SocketpairStream::from(OwnedFd::from(std_socket)))
 }
 
-pub fn make_poll_channel() -> io::Result<(PollEventSource, PollEventSender)> {
-  // This could be also a pipe or any other OS construct that can be poll()'ed in
-  // mio-0.8 And can be triggered (sent to) from the application.
-  // Socketpair is symmetric, but we decide to call one end receive and the other
-  // send. We use stream sockets, because the documentation says datagram
-  // sockets are not available on MacOS.
-  let (rec_sps, send_sps) = socketpair_stream()?;
 
+#[cfg(not(target_os = "windows"))]
+pub fn make_poll_channel() -> io::Result<(PollEventSource, PollEventSender)> {
+  let (rec_sps, send_sps) = socketpair_stream()?;
   let rec_sps = set_non_blocking(rec_sps)?;
   let send_sps = set_non_blocking(send_sps)?;
-
   let rec_mio_socket = unsafe { mio_08::net::TcpStream::from_raw_fd(rec_sps.as_raw_fd()) };
   let send_mio_socket = unsafe { mio_08::net::TcpStream::from_raw_fd(send_sps.as_raw_fd()) };
-
   Ok((
     PollEventSource {
       rec_sps,
@@ -64,6 +82,41 @@ pub fn make_poll_channel() -> io::Result<(PollEventSource, PollEventSender)> {
     },
   ))
 }
+
+#[cfg(target_os = "windows")]
+pub fn make_poll_channel() -> io::Result<(PollEventSource, PollEventSender)> {
+  let listener = match TcpListener::bind("127.0.0.1:0".parse().unwrap()) {
+    Ok(listener) => listener,
+    Err(err) => {error!("Failed to make listener!: {err}"); return Err(err);},
+  };
+
+  let addr = match listener.local_addr() {
+    Ok(listener) => listener,
+    Err(err) => {error!("Failed to retrieve local address: {err}"); return Err(err);},
+  };
+
+  let rec_mio_socket = match TcpStream::connect(addr) {
+    Ok(tcp_stream) => tcp_stream,
+    Err(err) => {error!("Failed to connect tcp stream: {err}"); return Err(err);},
+  };
+
+  let mut send_mio_socket = listener.accept();
+  while send_mio_socket.is_err() {
+    sleep(Duration::from_millis(100));
+    send_mio_socket = listener.accept();
+  }
+  let (send_mio_socket, _addr_send) = send_mio_socket?;
+  debug!("IPC socket: {addr:#?} <-> {_addr_send:#?}");
+  Ok((
+    PollEventSource {
+      rec_mio_socket: Mutex::new(rec_mio_socket),
+    },
+    PollEventSender {
+      send_mio_socket: Mutex::new(send_mio_socket),
+    },
+  ))
+}
+
 
 impl PollEventSender {
   pub fn send(&self) {

--- a/src/network/udp_listener.rs
+++ b/src/network/udp_listener.rs
@@ -3,7 +3,6 @@ use std::{
   net::{IpAddr, Ipv4Addr, SocketAddr},
 };
 
-use mio_06;
 use log::{debug, error, info, trace, warn};
 use socket2::{Domain, Protocol, SockAddr, Socket, Type};
 use bytes::{Bytes, BytesMut};

--- a/src/network/udp_sender.rs
+++ b/src/network/udp_sender.rs
@@ -26,7 +26,7 @@ impl UDPSender {
     #[cfg(not(windows))]
     let unicast_socket = {
       let saddr: SocketAddr = SocketAddr::new("0.0.0.0".parse().unwrap(), sender_port);
-      mio_08::net::UdpSocket::bind(&saddr)?
+      mio_08::net::UdpSocket::bind(saddr)?
     };
 
     #[cfg(windows)]


### PR DESCRIPTION
These changes restore Windows compatibility. Event notification is done using a normal socket instead of a socketpair because socketpair does not use sockets under the hood in Windows. The udp sender and udp listener needed to use mio 8 because mio 6 refused to actually send data. Some tests still seem to fail on Windows. 