### PR TITLE
Fix overly strict lifetime requirements for deserialization helpers

### DIFF
--- a/src/dds/key.rs
+++ b/src/dds/key.rs
@@ -31,10 +31,7 @@ use crate::serialization::pl_cdr_adapters::{PlCdrDeserializeError, PlCdrSerializ
 /// [`Key`]: trait.Key.html
 
 pub trait Keyed {
-  // type K: Key;  // This does not work yet is stable Rust, 2020-08-11
-  // Instead, where D:Keyed we do anything with D::K, we must specify bound:
-  // where <D as Keyed>::K : Key,
-  type K;
+  type K: Key;
 
   fn key(&self) -> Self::K;
 }

--- a/src/dds/pubsub.rs
+++ b/src/dds/pubsub.rs
@@ -15,7 +15,7 @@ use crate::{
   create_error_dropped, create_error_poisoned,
   dds::{
     adapters,
-    key::{Key, Keyed},
+    key::Keyed,
     no_key,
     no_key::{
       datareader::DataReader as NoKeyDataReader, datawriter::DataWriter as NoKeyDataWriter,
@@ -156,7 +156,6 @@ impl Publisher {
   ) -> CreateResult<WithKeyDataWriter<D, SA>>
   where
     D: Keyed,
-    <D as Keyed>::K: Key,
     SA: adapters::with_key::SerializerAdapter<D>,
   {
     self.inner_lock().create_datawriter(self, None, topic, qos)
@@ -171,7 +170,6 @@ impl Publisher {
   ) -> CreateResult<WithKeyDataWriter<D, CDRSerializerAdapter<D, LittleEndian>>>
   where
     D: Keyed + serde::Serialize,
-    <D as Keyed>::K: Key,
     <D as Keyed>::K: Serialize,
   {
     self.create_datawriter::<D, CDRSerializerAdapter<D, LittleEndian>>(topic, qos)
@@ -187,7 +185,6 @@ impl Publisher {
   ) -> CreateResult<WithKeyDataWriter<D, SA>>
   where
     D: Keyed,
-    <D as Keyed>::K: Key,
     SA: adapters::with_key::SerializerAdapter<D>,
   {
     self
@@ -203,7 +200,6 @@ impl Publisher {
   ) -> CreateResult<WithKeyDataWriter<D, CDRSerializerAdapter<D, LittleEndian>>>
   where
     D: Keyed + serde::Serialize,
-    <D as Keyed>::K: Key,
     <D as Keyed>::K: Serialize,
   {
     self.create_datawriter_with_entity_id::<D, CDRSerializerAdapter<D, LittleEndian>>(
@@ -468,7 +464,6 @@ impl InnerPublisher {
   ) -> CreateResult<WithKeyDataWriter<D, SA>>
   where
     D: Keyed,
-    <D as Keyed>::K: Key,
     SA: adapters::with_key::SerializerAdapter<D>,
   {
     // Data samples from DataWriter to HistoryCache
@@ -705,7 +700,6 @@ impl Subscriber {
   ) -> CreateResult<WithKeyDataReader<D, SA>>
   where
     D: Keyed,
-    <D as Keyed>::K: Key,
     SA: adapters::with_key::DeserializerAdapter<D>,
   {
     self.inner.create_datareader(self, topic, None, qos)
@@ -718,7 +712,6 @@ impl Subscriber {
   ) -> CreateResult<WithKeyDataReader<D, CDRDeserializerAdapter<D>>>
   where
     D: serde::de::DeserializeOwned + Keyed,
-    <D as Keyed>::K: Key,
     for<'de> <D as Keyed>::K: Deserialize<'de>,
   {
     self.create_datareader::<D, CDRDeserializerAdapter<D>>(topic, qos)
@@ -734,7 +727,6 @@ impl Subscriber {
   ) -> CreateResult<WithKeyDataReader<D, SA>>
   where
     D: Keyed,
-    <D as Keyed>::K: Key,
     SA: adapters::with_key::DeserializerAdapter<D>,
   {
     self
@@ -750,7 +742,6 @@ impl Subscriber {
   ) -> CreateResult<WithKeyDataReader<D, CDRDeserializerAdapter<D>>>
   where
     D: serde::de::DeserializeOwned + Keyed,
-    <D as Keyed>::K: Key,
     for<'de> <D as Keyed>::K: Deserialize<'de>,
   {
     self.create_datareader_with_entity_id::<D, CDRDeserializerAdapter<D>>(topic, entity_id, qos)
@@ -931,7 +922,6 @@ impl InnerSubscriber {
   ) -> CreateResult<WithKeyDataReader<D, SA>>
   where
     D: Keyed,
-    <D as Keyed>::K: Key,
     SA: adapters::with_key::DeserializerAdapter<D>,
   {
     let simple_dr =
@@ -950,7 +940,6 @@ impl InnerSubscriber {
   ) -> CreateResult<with_key::SimpleDataReader<D, SA>>
   where
     D: Keyed,
-    <D as Keyed>::K: Key,
     SA: adapters::with_key::DeserializerAdapter<D>,
   {
     // incoming data notification channel from Reader to DataReader
@@ -1050,7 +1039,6 @@ impl InnerSubscriber {
   ) -> CreateResult<WithKeyDataReader<D, SA>>
   where
     D: Keyed,
-    <D as Keyed>::K: Key,
     SA: adapters::with_key::DeserializerAdapter<D>,
   {
     if topic.kind() != TopicKind::WithKey {

--- a/src/dds/with_key/datareader.rs
+++ b/src/dds/with_key/datareader.rs
@@ -70,10 +70,7 @@ pub enum SelectByKey {
 /// *Note:* Many DataReader methods require mutable access to `self`, because
 /// they need to mutate the datasample cache, which is an essential content of
 /// this struct.
-pub struct DataReader<D: Keyed, DA: DeserializerAdapter<D> = CDRDeserializerAdapter<D>>
-where
-  <D as Keyed>::K: Key,
-{
+pub struct DataReader<D: Keyed, DA: DeserializerAdapter<D> = CDRDeserializerAdapter<D>> {
   simple_data_reader: SimpleDataReader<D, DA>,
   datasample_cache: DataSampleCache<D>, // DataReader-local cache of deserialized samples
 }
@@ -81,7 +78,6 @@ where
 impl<D: 'static, DA> DataReader<D, DA>
 where
   D: Keyed,
-  <D as Keyed>::K: Key,
   DA: DeserializerAdapter<D>,
 {
   pub(crate) fn from_simple_data_reader(simple_data_reader: SimpleDataReader<D, DA>) -> Self {
@@ -743,7 +739,6 @@ where
 impl<D, DA> Evented for DataReader<D, DA>
 where
   D: Keyed,
-  <D as Keyed>::K: Key,
   DA: DeserializerAdapter<D>,
 {
   // We just delegate all the operations to notification_receiver, since it
@@ -780,7 +775,6 @@ where
 impl<D, DA> mio_08::event::Source for DataReader<D, DA>
 where
   D: Keyed,
-  <D as Keyed>::K: Key,
   DA: DeserializerAdapter<D>,
 {
   fn register(
@@ -824,7 +818,6 @@ where
 impl<D, DA> StatusEvented<DataReaderStatus> for DataReader<D, DA>
 where
   D: Keyed,
-  <D as Keyed>::K: Key,
   DA: DeserializerAdapter<D>,
 {
   fn as_status_evented(&mut self) -> &dyn Evented {
@@ -844,7 +837,6 @@ impl<D, DA> HasQoSPolicy for DataReader<D, DA>
 where
   D: Keyed + 'static,
   DA: DeserializerAdapter<D>,
-  <D as Keyed>::K: Key,
 {
   fn qos(&self) -> QosPolicies {
     self.simple_data_reader.qos().clone()
@@ -854,7 +846,6 @@ where
 impl<D, DA> RTPSEntity for DataReader<D, DA>
 where
   D: Keyed + 'static,
-  <D as Keyed>::K: Key,
   DA: DeserializerAdapter<D>,
 {
   fn guid(&self) -> GUID {
@@ -870,16 +861,13 @@ where
 pub struct DataReaderStream<
   D: Keyed + 'static,
   DA: DeserializerAdapter<D> + 'static = CDRDeserializerAdapter<D>,
-> where
-  <D as Keyed>::K: Key,
-{
+> {
   datareader: Arc<Mutex<DataReader<D, DA>>>,
 }
 
 impl<D, DA> DataReaderStream<D, DA>
 where
   D: Keyed + 'static,
-  <D as Keyed>::K: Key,
   DA: DeserializerAdapter<D>,
 {
   /// Get a stream of status events
@@ -894,7 +882,6 @@ where
 impl<D, DA> Unpin for DataReaderStream<D, DA>
 where
   D: Keyed + 'static,
-  <D as Keyed>::K: Key,
   DA: DeserializerAdapter<D>,
 {
 }
@@ -902,7 +889,6 @@ where
 impl<D, DA> Stream for DataReaderStream<D, DA>
 where
   D: Keyed + 'static,
-  <D as Keyed>::K: Key,
   DA: DeserializerAdapter<D>,
 {
   type Item = ReadResult<Sample<D, D::K>>;
@@ -946,7 +932,6 @@ where
 impl<D, DA> FusedStream for DataReaderStream<D, DA>
 where
   D: Keyed + 'static,
-  <D as Keyed>::K: Key,
   DA: DeserializerAdapter<D>,
 {
   fn is_terminated(&self) -> bool {
@@ -960,16 +945,13 @@ where
 pub struct DataReaderEventStream<
   D: Keyed + 'static,
   DA: DeserializerAdapter<D> + 'static = CDRDeserializerAdapter<D>,
-> where
-  <D as Keyed>::K: Key,
-{
+> {
   datareader: Arc<Mutex<DataReader<D, DA>>>,
 }
 
 impl<D, DA> Stream for DataReaderEventStream<D, DA>
 where
   D: Keyed + 'static,
-  <D as Keyed>::K: Key,
   DA: DeserializerAdapter<D>,
 {
   type Item = ReadResult<DataReaderStatus>;
@@ -988,7 +970,6 @@ where
 impl<D, DA> FusedStream for DataReaderEventStream<D, DA>
 where
   D: Keyed + 'static,
-  <D as Keyed>::K: Key,
   DA: DeserializerAdapter<D>,
 {
   fn is_terminated(&self) -> bool {

--- a/src/dds/with_key/datasample.rs
+++ b/src/dds/with_key/datasample.rs
@@ -91,10 +91,7 @@ where
 
   // convenience shorthand to get the key directly, without digging out the
   // "value"
-  pub fn key(&self) -> D::K
-  where
-    <D as Keyed>::K: Key,
-  {
+  pub fn key(&self) -> D::K {
     match &self.value {
       Sample::Value(d) => d.key(),
       Sample::Dispose(k) => k.clone(),

--- a/src/dds/with_key/datasample_cache.rs
+++ b/src/dds/with_key/datasample_cache.rs
@@ -8,7 +8,7 @@ use log::{debug, error, info, warn};
 
 use crate::{
   dds::{
-    key::{Key, Keyed},
+    key::Keyed,
     qos::{policy, QosPolicies},
     readcondition::ReadCondition,
     sampleinfo::*,
@@ -57,7 +57,6 @@ struct SampleWithMetaData<D: Keyed> {
 impl<D> SampleWithMetaData<D>
 where
   D: Keyed,
-  <D as Keyed>::K: Key,
 {
   pub fn key(&self) -> D::K {
     match &self.sample {
@@ -70,7 +69,6 @@ where
 impl<D> DataSampleCache<D>
 where
   D: Keyed,
-  <D as Keyed>::K: Key,
 {
   pub fn new(qos: QosPolicies) -> Self {
     Self {

--- a/src/dds/with_key/datawriter.rs
+++ b/src/dds/with_key/datawriter.rs
@@ -21,7 +21,6 @@ use crate::{
     dds_entity::DDSEntity,
     ddsdata::DDSData,
     helpers::*,
-    key,
     pubsub::Publisher,
     qos::{
       policy::{Liveliness, Reliability},
@@ -39,7 +38,7 @@ use crate::{
     cache_change::ChangeKind, duration, entity::RTPSEntity, guid::GUID, rpc::SampleIdentity,
     sequence_number::SequenceNumber, time::Timestamp,
   },
-  Key, Keyed, TopicDescription,
+  Keyed, TopicDescription,
 };
 
 // TODO: Move the write options and the builder type to some lower-level module
@@ -189,7 +188,6 @@ where
 impl<D, SA> DataWriter<D, SA>
 where
   D: Keyed,
-  <D as Keyed>::K: Key,
   SA: SerializerAdapter<D>,
 {
   #[allow(clippy::too_many_arguments)]
@@ -991,7 +989,6 @@ where
 pub struct AsyncWrite<'a, D, SA>
 where
   D: Keyed,
-  <D as key::Keyed>::K: Key,
   SA: SerializerAdapter<D>,
 {
   writer: &'a DataWriter<D, SA>,
@@ -1007,7 +1004,6 @@ where
 impl<'a, D, SA> Unpin for AsyncWrite<'a, D, SA>
 where
   D: Keyed,
-  <D as key::Keyed>::K: Key,
   SA: SerializerAdapter<D>,
 {
 }
@@ -1015,7 +1011,6 @@ where
 impl<'a, D, SA> Future for AsyncWrite<'a, D, SA>
 where
   D: Keyed,
-  <D as key::Keyed>::K: Key,
   SA: SerializerAdapter<D>,
 {
   type Output = WriteResult<SampleIdentity, D>;
@@ -1095,7 +1090,6 @@ where
 impl<'a, D, SA> Future for AsyncWaitForAcknowledgments<'a, D, SA>
 where
   D: Keyed,
-  <D as key::Keyed>::K: Key,
   SA: SerializerAdapter<D>,
 {
   type Output = WriteResult<bool, ()>;
@@ -1181,7 +1175,6 @@ where
 impl<D, SA> DataWriter<D, SA>
 where
   D: Keyed,
-  <D as Keyed>::K: Key,
   SA: SerializerAdapter<D>,
 {
   pub async fn async_write(
@@ -1274,7 +1267,10 @@ mod tests {
 
   use super::*;
   use crate::{
-    dds::{key::Keyed, participant::DomainParticipant},
+    dds::{
+      key::{Key, Keyed},
+      participant::DomainParticipant,
+    },
     serialization::cdr_serializer::CDRSerializerAdapter,
     structure::topic_kind::TopicKind,
     test::random_data::*,

--- a/src/dds/with_key/simpledatareader.rs
+++ b/src/dds/with_key/simpledatareader.rs
@@ -69,10 +69,7 @@ impl<K: Key> ReadState<K> {
 
 /// SimpleDataReaders can only do "take" semantics and does not have
 /// any deduplication or other DataSampleCache functionality.
-pub struct SimpleDataReader<D: Keyed, DA: DeserializerAdapter<D> = CDRDeserializerAdapter<D>>
-where
-  <D as Keyed>::K: Key,
-{
+pub struct SimpleDataReader<D: Keyed, DA: DeserializerAdapter<D> = CDRDeserializerAdapter<D>> {
   #[allow(dead_code)] // TODO: This is currently unused, because we do not implement
   // any subscriber-wide QoS policies, such as ordered or coherent access.
   // Remove this attribute when/if such things are implemented.
@@ -107,7 +104,6 @@ where
 impl<D, DA> Drop for SimpleDataReader<D, DA>
 where
   D: Keyed,
-  <D as Keyed>::K: Key,
   DA: DeserializerAdapter<D>,
 {
   fn drop(&mut self) {
@@ -134,7 +130,6 @@ where
 impl<D: 'static, DA> SimpleDataReader<D, DA>
 where
   D: Keyed,
-  <D as Keyed>::K: Key,
   DA: DeserializerAdapter<D>,
 {
   #[allow(clippy::too_many_arguments)]
@@ -381,7 +376,6 @@ where
 impl<D, DA> Evented for SimpleDataReader<D, DA>
 where
   D: Keyed,
-  <D as Keyed>::K: Key,
   DA: DeserializerAdapter<D>,
 {
   // We just delegate all the operations to notification_receiver, since it
@@ -418,7 +412,6 @@ where
 impl<D, DA> mio_08::event::Source for SimpleDataReader<D, DA>
 where
   D: Keyed,
-  <D as Keyed>::K: Key,
   DA: DeserializerAdapter<D>,
 {
   fn register(
@@ -447,7 +440,6 @@ where
 impl<D, DA> StatusEvented<DataReaderStatus> for SimpleDataReader<D, DA>
 where
   D: Keyed,
-  <D as Keyed>::K: Key,
   DA: DeserializerAdapter<D>,
 {
   fn as_status_evented(&mut self) -> &dyn Evented {
@@ -466,7 +458,6 @@ where
 impl<D, DA> RTPSEntity for SimpleDataReader<D, DA>
 where
   D: Keyed + DeserializeOwned,
-  <D as Keyed>::K: Key,
   DA: DeserializerAdapter<D>,
 {
   fn guid(&self) -> GUID {
@@ -483,9 +474,7 @@ pub struct SimpleDataReaderStream<
   'a,
   D: Keyed + 'static,
   DA: DeserializerAdapter<D> + 'static = CDRDeserializerAdapter<D>,
-> where
-  <D as Keyed>::K: Key,
-{
+> {
   simple_datareader: &'a SimpleDataReader<D, DA>,
 }
 
@@ -496,7 +485,6 @@ pub struct SimpleDataReaderStream<
 impl<'a, D, DA> Unpin for SimpleDataReaderStream<'a, D, DA>
 where
   D: Keyed + 'static,
-  <D as Keyed>::K: Key,
   DA: DeserializerAdapter<D>,
 {
 }
@@ -504,7 +492,6 @@ where
 impl<'a, D, DA> Stream for SimpleDataReaderStream<'a, D, DA>
 where
   D: Keyed + 'static,
-  <D as Keyed>::K: Key,
   DA: DeserializerAdapter<D>,
 {
   type Item = ReadResult<DeserializedCacheChange<D>>;
@@ -549,7 +536,6 @@ where
 impl<'a, D, DA> FusedStream for SimpleDataReaderStream<'a, D, DA>
 where
   D: Keyed + 'static,
-  <D as Keyed>::K: Key,
   DA: DeserializerAdapter<D>,
 {
   fn is_terminated(&self) -> bool {
@@ -564,16 +550,13 @@ pub struct SimpleDataReaderEventStream<
   'a,
   D: Keyed + 'static,
   DA: DeserializerAdapter<D> + 'static = CDRDeserializerAdapter<D>,
-> where
-  <D as Keyed>::K: Key,
-{
+> {
   simple_datareader: &'a SimpleDataReader<D, DA>,
 }
 
 impl<'a, D, DA> Stream for SimpleDataReaderEventStream<'a, D, DA>
 where
   D: Keyed + 'static,
-  <D as Keyed>::K: Key,
   DA: DeserializerAdapter<D>,
 {
   type Item = ReadResult<DataReaderStatus>;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -155,7 +155,6 @@
 //! // Getting reference to actual data from the data sample
 //! let actual_data = data_sample.value();
 //! ```
-#![deny(clippy::all)]
 #![warn(clippy::needless_pass_by_value, clippy::semicolon_if_nothing_returned)]
 #![allow(
   // option_map_unit_fn suggests changing option.map( ) with () return value to if let -construct,

--- a/src/ros2/ros_node.rs
+++ b/src/ros2/ros_node.rs
@@ -10,7 +10,7 @@ use serde::{de::DeserializeOwned, Serialize};
 use crate::{
   dds::{
     adapters::{no_key, with_key},
-    key::{Key, Keyed},
+    key::Keyed,
     pubsub::{Publisher, Subscriber},
     qos::QosPolicies,
     result::CreateError,
@@ -554,7 +554,6 @@ impl RosNode {
   ) -> Result<KeyedRosSubscriber<D, DA>, CreateError>
   where
     D: Keyed + DeserializeOwned + 'static,
-    D::K: Key,
   {
     let sub = self
       .ros_participant
@@ -600,7 +599,6 @@ impl RosNode {
   ) -> Result<KeyedRosPublisher<D, SA>, CreateError>
   where
     D: Keyed + Serialize,
-    D::K: Key,
   {
     let p = self
       .ros_participant

--- a/src/test/test_properties.rs
+++ b/src/test/test_properties.rs
@@ -46,7 +46,6 @@ trait TestingTrait {
 impl<'a, D: 'static, SA> DataReader<'a, D, SA>
 where
   D: DeserializeOwned + Keyed,
-  <D as Keyed>::K: Key,
   SA: DeserializerAdapter<D>,
   {
 


### PR DESCRIPTION
And other improvements:

- Don't deny clippy lints to avoid breakage when new lints are created
- Add `Key` bound on `Keyed::K` so that we don't need to specify it on every usage