### PR TITLE
Fix send_mio_socket type when target_os="windows"

### DIFF
--- a/src/mio_source.rs
+++ b/src/mio_source.rs
@@ -98,7 +98,7 @@ pub fn make_poll_channel() -> io::Result<(PollEventSource, PollEventSender)> {
       rec_mio_socket: Mutex::new(rec_mio_socket),
     },
     PollEventSender {
-      send_mio_socket: Mutex::new(send_mio_socket),
+      send_mio_socket: Arc::new(Mutex::new(send_mio_socket)),
     },
   ))
 }


### PR DESCRIPTION
Hi there,

Thanks for creating this nice repo. I suggest I catch a tiny bug in `mio_source.rs`: the type of `send_mio_socket ` in struct `PollEventSender` should be `Arc<Mutex<...>>`.

Best,
Levi