### PR TITLE
Access SampleInfo from async reader interface

### DIFF
--- a/examples/async_shapes_demo/main.rs
+++ b/examples/async_shapes_demo/main.rs
@@ -237,7 +237,7 @@ fn main() {
         let mut run = true;
         let stop = stop_receiver.recv().fuse();
         pin_mut!(stop);
-        let mut datareader_stream = datareader.async_sample_stream();
+        let mut datareader_stream = datareader.async_bare_sample_stream();
         let mut datareader_event_stream = datareader_stream.async_event_stream();
         while run {
           futures::select! {

--- a/examples/async_shapes_demo/main.rs
+++ b/examples/async_shapes_demo/main.rs
@@ -237,15 +237,15 @@ fn main() {
         let mut run = true;
         let stop = stop_receiver.recv().fuse();
         pin_mut!(stop);
-        let mut datareader_stream = datareader.async_bare_sample_stream();
+        let mut datareader_stream = datareader.async_sample_stream();
         let mut datareader_event_stream = datareader_stream.async_event_stream();
         while run {
           futures::select! {
             _ = stop => run = false,
             r = datareader_stream.select_next_some() => {
               match r {
-                Ok(v) =>
-                  match v {
+                Ok(s) =>
+                  match s.into_value() {
                     Sample::Value(sample) => println!(
                       "{:10.10} {:10.10} {:3.3} {:3.3} [{}]",
                       topic.name(),

--- a/examples/hello_world_subscriber/main.rs
+++ b/examples/hello_world_subscriber/main.rs
@@ -71,10 +71,12 @@ fn main() {
 
         result = sample_stream.select_next_some() => {
           match result {
-            Ok(Sample::Value(hello_msg)) =>
-              println!("Received: {hello_msg:?}"),
-            Ok(Sample::Dispose(key)) =>
-              println!("Disposed hello with key={key}"),
+            Ok(s) => match s.into_value() {
+              Sample::Value(hello_msg) =>
+                println!("Received: {hello_msg:?}"),
+              Sample::Dispose(key) =>
+                println!("Disposed hello with key={key}"),
+            }
             Err(e) =>
               println!("Oh no, DDS read error: {e:?}"),
           }

--- a/examples/no_key_async_usage_example/main.rs
+++ b/examples/no_key_async_usage_example/main.rs
@@ -72,14 +72,14 @@ fn main() {
       .unwrap();
 
     smol::block_on(async {
-      let mut datareader_stream = reader.async_bare_sample_stream();
+      let mut datareader_stream = reader.async_sample_stream();
       let mut datareader_event_stream = datareader_stream.async_event_stream();
 
       loop {
         futures::select! {
           r=datareader_stream.select_next_some()=>{
             match r{
-              Ok(d)=>{println!("{}",d.a)},
+              Ok(d)=>{println!("{}", d.value().a)},
               Err(e)=> {
                 println!("{:?}", e);
                 break;

--- a/examples/no_key_async_usage_example/main.rs
+++ b/examples/no_key_async_usage_example/main.rs
@@ -72,7 +72,7 @@ fn main() {
       .unwrap();
 
     smol::block_on(async {
-      let mut datareader_stream = reader.async_sample_stream();
+      let mut datareader_stream = reader.async_bare_sample_stream();
       let mut datareader_event_stream = datareader_stream.async_event_stream();
 
       loop {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -83,8 +83,9 @@
 //! DataReader and DataWriter can do Rust async I/O by converting themselves to
 //! [`futures::stream::Stream`]s.
 //! * [`crate::dds::with_key::DataReader::async_sample_stream`] to get data
-//! * [`crate::dds::with_key::DataReaderStream::async_event_stream`] to get
-//!   status events
+//! * [`crate::dds::with_key::DataReader::async_bare_sample_stream`] to get bare data
+//! * [`crate::dds::with_key::BareDataReaderStream::async_event_stream`] or
+//!   [`crate::dds::with_key::DataReaderStream::async_event_stream`] to get data status events
 //!
 //! See exampe `async_shapes_demo`.
 //!
@@ -217,9 +218,7 @@ pub use dds::{
 /// CDR.
 pub use serialization::RepresentationIdentifier;
 #[doc(inline)]
-pub use serialization::{
-  CDRDeserializerAdapter, CDRSerializerAdapter, CdrDeserializer, CdrSerializer,
-};
+pub use serialization::{CDRDeserializerAdapter, CDRSerializerAdapter, CdrDeserializer, CdrSerializer};
 pub use structure::{
   duration::Duration, entity::RTPSEntity, guid::GUID, sequence_number::SequenceNumber,
   time::Timestamp,


### PR DESCRIPTION
This pull-request resolve issue #298.

## Modification description

- Renamed current `async_sample_stream` (bare) to `async_bare_sample_stream`.
- Implemented the non-bare `async_sample_stream`, copying the same machinery as bare, replacing calls to `take_bare` by `take`.

## Test Performed

In async examples, replaced calls to the old `async_sample_stream` (bare) to the new `async_sample_stream` (non-bare), updating the sample handling.

## Functional impact

One now has the option to access `SampleInfo` from the async reader interface.

All users of the crate will have to adapt code using the async interface either by changing to the `async_bare_sample_stream` or adapt their `Sample` handlers if they choose to use the non-bare `async_sample_stream` interface. 