### PR TITLE
Fix silent event loss in DomainParticipant status channel

### DIFF
--- a/src/dds/participant.rs
+++ b/src/dds/participant.rs
@@ -226,8 +226,12 @@ impl DomainParticipantBuilder {
     let (discovery_command_sender, discovery_command_receiver) =
       mio_channel::sync_channel::<DiscoveryCommand>(64);
 
-    // Channel used to report noteworthy events to DomainParticipant
-    let (status_sender, status_receiver) = sync_status_channel(16)?;
+    // Channel used to report noteworthy events to DomainParticipant.
+    // Capacity must be large enough to absorb the SEDP burst when multiple
+    // participants are discovered at once. A single participant can expose
+    // many endpoints (e.g. ~16 in a typical ROS 2 node), so 2048 handles
+    // large deployments without silent event loss.
+    let (status_sender, status_receiver) = sync_status_channel(2048)?;
 
     #[cfg(not(feature = "security"))]
     let security_plugins_handle = None;

--- a/src/dds/statusevents.rs
+++ b/src/dds/statusevents.rs
@@ -103,7 +103,7 @@ impl<T> StatusChannelSender<T> {
         Ok(())
       }
       Err(mio_channel::TrySendError::Full(_tt)) => {
-        trace!("StatusChannelSender cannot send new status changes, channel is full.");
+        warn!("StatusChannelSender cannot send new status changes, channel is full.");
         // It is perfectly normal to fail due to full channel, because
         // no-one is required to be listening to these.
         self.signal_sender.send(); // kick the receiver anyway


### PR DESCRIPTION
## Summary

The `DomainParticipantStatusEvent` channel silently drops events when its capacity is exceeded. The `try_send` implementation converts a Full error into `Ok(())`, so neither the sender nor the consumer can detect the loss. The only indication is a trace!-level log that is invisible at normal log levels.

This PR:

- Increases the channel capacity from 16 to 2048
- Upgrades the overflow log from trace! to warn!
- Minor formatting fixes (comment alignment, import grouping)

### How was this discovered

I discovered this bug while building a ROS 2 application that uses RustDDS. When using the status_listener() API to introspect the DDS graph, some nodes' services and topics would not show up at all. Which nodes were visible varied between runs. After ruling out consumer-side issues and confirming SEDP was delivering all data correctly, we traced the problem to the bounded status channel silently dropping events.

### Why 16 is not enough

A single DDS participant can expose many endpoints. When SEDP discovers a remote participant, it generates `WriterDetected` and `ReaderDetected` events for every endpoint in a burst — faster than the consumer can drain.

For example, a typical ROS 2 node creates ~9 writers and ~7 readers (~16 status events per node). Two nodes produce ~32 events, already exceeding the channel capacity. At 10 nodes (~160 events), 90% of events are silently lost. This is not specific to ROS 2 — any DDS application with multiple endpoints per participant will hit this with modest scale.

### Why 2048

- Covers realistic deployments. 2048 handles ~120 participants in a single SEDP burst, which covers the vast majority of DDS systems.
- Negligible cost. The channel is a notification pipe — the actual endpoint data already lives in the DiscoveryDB. At ~200-500 bytes per event, peak  buffer is ~1 MB. That's nothing compared to the SPDP/SEDP threads, network buffers, and DDSCache already maintained.
- No performance impact. Send/receive are O(1) regardless of capacity. In steady state the channel is nearly empty — it only fills during initial discovery bursts.
- No behavioral change. Events that previously went through still go through. The only difference is that events that were silently dropped now have room in the channel.