### PR TITLE
Expose PID_USER_DATA from SEDP endpoint discovery

### DIFF
--- a/src/dds/statusevents.rs
+++ b/src/dds/statusevents.rs
@@ -395,6 +395,7 @@ pub struct EndpointDescription {
   pub topic_name: String,
   pub type_name: String,
   pub qos: QosPolicies,
+  pub user_data: Vec<u8>,
 }
 
 #[derive(Debug, Clone)]

--- a/src/discovery/discovery_db.rs
+++ b/src/discovery/discovery_db.rs
@@ -662,6 +662,7 @@ impl DiscoveryDB {
       reader_proxy: ReaderProxy::from(reader_proxy),
       subscription_topic_data: subscription_data,
       content_filter,
+      user_data: Vec::new(),
     };
 
     self
@@ -943,6 +944,7 @@ mod tests {
       reader_proxy: reader1.clone(),
       subscription_topic_data: reader1sub.clone(),
       content_filter: None,
+      user_data: Vec::new(),
     };
     discovery_db.update_subscription(&dreader1);
 
@@ -954,6 +956,7 @@ mod tests {
       reader_proxy: reader2,
       subscription_topic_data: reader2sub,
       content_filter: None,
+      user_data: Vec::new(),
     };
     discovery_db.update_subscription(&dreader2);
 
@@ -963,6 +966,7 @@ mod tests {
       reader_proxy: reader3,
       subscription_topic_data: reader3sub,
       content_filter: None,
+      user_data: Vec::new(),
     };
     discovery_db.update_subscription(&dreader3);
 

--- a/src/discovery/sedp_messages.rs
+++ b/src/discovery/sedp_messages.rs
@@ -301,6 +301,7 @@ pub struct DiscoveredReaderData {
   pub reader_proxy: ReaderProxy,
   pub subscription_topic_data: SubscriptionBuiltinTopicData,
   pub content_filter: Option<ContentFilterProperty>,
+  pub user_data: Vec<u8>,
 }
 
 impl DiscoveredReaderData {
@@ -321,6 +322,7 @@ impl DiscoveredReaderData {
       reader_proxy,
       subscription_topic_data,
       content_filter: None,
+      user_data: Vec::new(),
     }
   }
 }
@@ -404,6 +406,12 @@ impl PlCdrDeserialize for DiscoveredReaderData {
 
     let qos = QosPolicies::from_parameter_list(ctx, &pl_map)?;
 
+    let user_data = pl_map
+      .get(&ParameterId::PID_USER_DATA)
+      .and_then(|v| v.first())
+      .map(|p| p.value.clone())
+      .unwrap_or_default();
+
     Ok(DiscoveredReaderData {
       reader_proxy: ReaderProxy::new(
         guid,
@@ -420,6 +428,7 @@ impl PlCdrDeserialize for DiscoveredReaderData {
         security_info,
       ),
       content_filter,
+      user_data,
     })
   }
 }
@@ -476,6 +485,7 @@ impl ParameterListable for DiscoveredReaderData {
           security_info,
         },
       content_filter,
+      user_data: _,
     } = self;
 
     let mut pl = ParameterList::new();
@@ -747,6 +757,7 @@ pub struct DiscoveredWriterData {
 
   pub writer_proxy: WriterProxy,
   pub publication_topic_data: PublicationBuiltinTopicData,
+  pub user_data: Vec<u8>,
 }
 
 impl Keyed for DiscoveredWriterData {
@@ -781,6 +792,7 @@ impl DiscoveredWriterData {
       last_updated: Instant::now(),
       writer_proxy,
       publication_topic_data,
+      user_data: Vec::new(),
     }
   }
 }
@@ -847,6 +859,12 @@ impl PlCdrDeserialize for DiscoveredWriterData {
 
     let qos = QosPolicies::from_parameter_list(ctx, &pl_map)?;
 
+    let user_data = pl_map
+      .get(&ParameterId::PID_USER_DATA)
+      .and_then(|v| v.first())
+      .map(|p| p.value.clone())
+      .unwrap_or_default();
+
     Ok(DiscoveredWriterData {
       last_updated: Instant::now(),
       writer_proxy: WriterProxy {
@@ -855,6 +873,7 @@ impl PlCdrDeserialize for DiscoveredWriterData {
         multicast_locator_list,
         data_max_size_serialized,
       },
+      user_data,
       publication_topic_data: PublicationBuiltinTopicData::new_with_qos(
         guid,
         participant_guid,
@@ -918,6 +937,7 @@ impl ParameterListable for DiscoveredWriterData {
           #[cfg(feature = "security")]
           security_info,
         },
+      user_data: _,
     } = self;
 
     let mut pl = ParameterList::new();
@@ -1350,6 +1370,7 @@ mod tests {
       reader_proxy,
       subscription_topic_data: sub_topic_data,
       content_filter: Some(content_filter),
+      user_data: Vec::new(),
     };
 
     // serialize
@@ -1406,6 +1427,7 @@ mod tests {
       last_updated: Instant::now(),
       writer_proxy,
       publication_topic_data: pub_topic_data,
+      user_data: Vec::new(),
     };
 
     let sdata = dwd

--- a/src/rtps/dp_event_loop.rs
+++ b/src/rtps/dp_event_loop.rs
@@ -710,6 +710,7 @@ impl DPEventLoop {
           topic_name: remote_reader.subscription_topic_data.topic_name.clone(),
           type_name: remote_reader.subscription_topic_data.type_name().clone(),
           qos: remote_reader.subscription_topic_data.qos(),
+          user_data: remote_reader.user_data.clone(),
         },
       })
       .unwrap_or_else(|e| error!("Cannot report participant status: {e:?}"));
@@ -798,6 +799,7 @@ impl DPEventLoop {
           topic_name: remote_writer.publication_topic_data.topic_name.clone(),
           type_name: remote_writer.publication_topic_data.type_name.clone(),
           qos: remote_writer.publication_topic_data.qos(),
+          user_data: remote_writer.user_data.clone(),
         },
       })
       .unwrap_or_else(|e| error!("Cannot report participant status: {e:?}"));


### PR DESCRIPTION
## Summary

Expose `PID_USER_DATA` (0x002C) from SEDP-discovered endpoints. This is a standard DDS parameter that RustDDS currently discards during parsing.

The `user_data` field is added as `Vec<u8>` to `DiscoveredReaderData`, `DiscoveredWriterData`, and `EndpointDescription`, making it available through `WriterDetected`/`ReaderDetected` status events.

## Use case

ROS 2 Jazzy embeds type hashes in `PID_USER_DATA` (e.g. `typehash=RIHS01_<hex>;`). These hashes are needed to call the `get_type_description` service for runtime message schema resolution, enabling pure-DDS tools to deserialize ROS 2 messages without a ROS 2 installation.

## Design

- **`Vec<u8>`** — matches the DDS spec definition of opaque bytes; no interpretation imposed.
- **Empty vec when absent** — avoids `Option` wrapping since most endpoints don't set it.
- **Not serialized back out** — local endpoints set user data through QoS, not by echoing remote data