### PR TITLE
Fix RUSTSEC-2024-0436 by replacing `paste` with `pastey`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,7 +55,7 @@ rand = "0.9.0"
 chrono = { version = "0.4", features = ["serde"] }
 enumflags2 = { version = "0.7.7", features = ["serde"] }
 if-addrs = "0.14"
-paste = "1"
+pastey = "0.2"
 md5 = "0.8.0"
 socket2 = { version = "0.6", features = ["all"] }
 bytes = "1.11"

--- a/src/discovery/discovery.rs
+++ b/src/discovery/discovery.rs
@@ -7,7 +7,7 @@ use std::{
 use log::{debug, error, info, trace, warn};
 use mio_06::{Events, Poll, PollOpt, Ready};
 use mio_extras::{channel as mio_channel, timer::Timer};
-use paste::paste; // token pasting macro
+use pastey::paste; // token pasting macro
 
 use crate::{
   dds::{
@@ -135,9 +135,7 @@ mod with_key {
   use mio_extras::timer::Timer;
 
   use super::{DataReaderPlCdr, DataWriterPlCdr};
-  use crate::{
-    polling::TimerPolicy, serialization::pl_cdr_adapters::*, Key, Keyed, Topic, TopicKind,
-  };
+  use crate::{polling::TimerPolicy, serialization::pl_cdr_adapters::*, Key, Keyed, Topic, TopicKind};
 
   pub const TOPIC_KIND: TopicKind = TopicKind::WithKey;
 


### PR DESCRIPTION
`paste` is unmaintained and `pastey` is a drop-in replacement.

Also see https://github.com/Atostek/cdr-encoding/issues/7