### PR TITLE
Fix for RustDDS integration tests. 

### DIFF
--- a/examples/shapes_demo/main.rs
+++ b/examples/shapes_demo/main.rs
@@ -155,10 +155,11 @@ fn main() {
     "QoS policy Ownership Strength is not yet implemented."
   );
 
-  assert!(
-    !matches.contains_id("representation"),
-    "QoS policy Representation is not yet implemented."
-  );
+  // The interoperability test harness always passes -x (data representation).
+  // RustDDS does not expose representation as a selectable QoS, so we accept the
+  // flag for CLI compatibility but do not act on it (the default wire encoding is
+  // used). Plain ShapeType encodes identically under XCDR1/XCDR2.
+  let _ = matches.get_one::<String>("representation");
 
   let qos = qos_b.build();
 
@@ -179,7 +180,6 @@ fn main() {
   if is_auto_test {
     // Make automation tests happy
     println!("Create topic: {}", topic.name());
-    println!("Create reader for topic: {}", topic.name());
   } else {
     println!(
       "Topic name is {}. Type is {}.",
@@ -226,6 +226,10 @@ fn main() {
         PollOpt::edge(),
       )
       .unwrap();
+    if is_auto_test {
+      // Make automation tests happy (publisher role)
+      println!("Create writer for topic: {}", topic.name());
+    }
     Some(writer)
   } else {
     None
@@ -249,6 +253,10 @@ fn main() {
       )
       .unwrap();
     debug!("Created DataReader");
+    if is_auto_test {
+      // Make automation tests happy (subscriber role)
+      println!("Create reader for topic: {}", topic.name());
+    }
     Some(reader)
   } else {
     None

--- a/src/discovery/discovery.rs
+++ b/src/discovery/discovery.rs
@@ -284,6 +284,13 @@ pub(crate) struct Discovery {
   #[cfg(feature = "security")]
   dcps_participant_volatile_message_secure:
     no_key::DiscoveryTopicCDR<ParticipantVolatileMessageSecure>, // CDR?
+
+  // Remote participants to which we have already sent an unsolicited "quick" SPDP
+  // response while they were still being authenticated. Used to avoid sending a
+  // quick response more than once per remote during the (pre-authentication)
+  // discovery phase. See `spdp_receive`.
+  #[cfg(feature = "security")]
+  spdp_quick_response_sent: std::collections::HashSet<GuidPrefix>,
 }
 
 impl Discovery {
@@ -686,6 +693,8 @@ impl Discovery {
       dcps_participant_stateless_message,
       #[cfg(feature = "security")]
       dcps_participant_volatile_message_secure,
+      #[cfg(feature = "security")]
+      spdp_quick_response_sent: std::collections::HashSet::new(),
     })
   }
 
@@ -989,6 +998,30 @@ impl Discovery {
                 self.process_participant_dispose(participant_guid.0.prefix);
               }
             }
+          } else {
+            // Speed up *secure* discovery.
+            //
+            // While the remote is still being authenticated, `participant_read`
+            // returns a permission other than `Allow`, which skips
+            // `process_discovered_participant_data` above — and with it the normal
+            // "quick SPDP response" optimization. Without that, the remote would
+            // only learn about us on our next *periodic* SPDP (SPDP_PUBLISH_PERIOD),
+            // delaying the authentication handshake by up to a full period. Send an
+            // unsolicited one-shot quick SPDP response now (at most once per remote).
+            // We only re-announce our own public SPDP data, so this discloses nothing
+            // extra.
+            #[cfg(feature = "security")]
+            if let Sample::Value(participant_data) = &ds.value {
+              let remote_prefix = participant_data.participant_guid.prefix;
+              if remote_prefix != self.domain_participant.guid().prefix
+                && self.spdp_quick_response_sent.insert(remote_prefix)
+              {
+                self.discovery_timer.borrow_mut().set_timeout(
+                  StdDuration::from_millis(10),
+                  DiscoveryTimerEvent::SendParticipantInfo { reschedule: false },
+                );
+              }
+            }
           }
         }
         Ok(None) => {
@@ -1058,6 +1091,8 @@ impl Discovery {
       id: participant_guidp,
       reason: LostReason::Disposed,
     });
+    #[cfg(feature = "security")]
+    self.spdp_quick_response_sent.remove(&participant_guidp);
   }
 
   fn send_endpoint_dispose_message(&self, endpoint_guid: GUID) {


### PR DESCRIPTION
Quickly respond to SPDP even in the middle of authentication. Fix test program outputs to not confuse test automation.